### PR TITLE
Fix memaccess warning

### DIFF
--- a/src/apps/dggrid/clipper.cpp
+++ b/src/apps/dggrid/clipper.cpp
@@ -718,7 +718,7 @@ void DisposeOutPts(OutPt*& pp)
 
 inline void InitEdge(TEdge* e, TEdge* eNext, TEdge* ePrev, const IntPoint& Pt)
 {
-  std::memset(e, 0, sizeof(TEdge));
+  *e = TEdge();
   e->Next = eNext;
   e->Prev = ePrev;
   e->Curr = Pt;


### PR DESCRIPTION
../src/apps/dggrid/clipper.cpp:721:34: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct ClipperLib::TEdge’; use assignment or value-initialization instead [-Wclass-memaccess]