### PR TITLE
Resolve truncation warning

### DIFF
--- a/src/lib/shapelib/lib/shpopen.c
+++ b/src/lib/shapelib/lib/shpopen.c
@@ -2415,7 +2415,7 @@ SHPReadObject( SHPHandle psSHP, int hEntity )
             psShape->panPartType == NULL)
         {
             snprintf(szErrorMsg, sizeof(szErrorMsg),
-                    "Not enough memory to allocate requested memory (nPoints=%u, nParts=%u) for shape %d. "
+                    "Insufficient memory for allocation (nPoints=%u, nParts=%u) for shape %d. "
                     "Probably broken SHP file", nPoints, nParts, hEntity );
             szErrorMsg[sizeof(szErrorMsg)-1] = '\0';
             psSHP->sHooks.Error( szErrorMsg );


### PR DESCRIPTION
../src/lib/shapelib/lib/shpopen.c:2418:21: warning: ‘. Probably broken SHP file’ directive output may be truncated writing 26 bytes into a region of size between 25 and 48