### PR TITLE
Ensure C++ version of streampos is used

### DIFF
--- a/src/lib/dglib/include/DgInLocTextFile.h
+++ b/src/lib/dglib/include/DgInLocTextFile.h
@@ -44,12 +44,12 @@ class DgInLocTextFile : public ifstream, public DgInLocFile {
 
    public:
 
-      DgInLocTextFile (const DgRFBase& rfIn, 
-                       const string* fileNameIn = NULL, 
+      DgInLocTextFile (const DgRFBase& rfIn,
+                       const string* fileNameIn = NULL,
                        bool isPointFileIn = false,
                        DgReportLevel failLevel = DgBase::Fatal);
 
-      void rewind (void) { seekg(streampos(0)); clear(); }
+      void rewind (void) { seekg(std::streampos(0)); clear(); }
 
       virtual bool open (const string* fileName = NULL,
                  DgReportLevel failLevel = DgBase::Fatal);

--- a/src/lib/dglib/include/DgInputStream.h
+++ b/src/lib/dglib/include/DgInputStream.h
@@ -21,7 +21,7 @@
 // DgInputStream.h: DgInputStream class definition
 //
 //   This class provides wrappers around some basic input stream functionality
-//   to increase ease of use. 
+//   to increase ease of use.
 //
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -43,12 +43,12 @@ class DgInputStream : public ifstream, public DgBase {
       DgInputStream (void) : DgBase ("DgInputStream") {}
 
       DgInputStream (const string& fileNameIn,
-                     const string& suffixIn  = string(""), 
+                     const string& suffixIn  = string(""),
                      DgReportLevel failLevel = DgBase::Fatal);
 
       bool open (string fileName, DgReportLevel failLevel = DgBase::Fatal);
 
-      static void setDefaultDir (const string& defaultDirIn) 
+      static void setDefaultDir (const string& defaultDirIn)
                      { defaultDirectory_ = defaultDirIn; }
 
       void setSuffix (const string& suffixIn) { suffix_ = suffixIn; }
@@ -57,7 +57,7 @@ class DgInputStream : public ifstream, public DgBase {
       const string& fileName   (void) const { return fileName_; }
       const string& suffix     (void) const { return suffix_; }
 
-      void rewind (void) { seekg(streampos(0)); clear(); }
+      void rewind (void) { seekg(std::streampos(0)); clear(); }
 
    private:
 


### PR DESCRIPTION
CRAN warns because `streampos` alone does not trigger the C++ `std::streampos`, so this PR fixes that.