### PR TITLE
Fix more memory leaks primarily by not new-constructing objects

### DIFF
--- a/src/lib/dglib/include/DgDiscRF.h
+++ b/src/lib/dglib/include/DgDiscRF.h
@@ -32,7 +32,7 @@
 #include "DgPolygon.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-template<class A, class B, class DB> 
+template<class A, class B, class DB>
 class DgDiscRF : public DgRF<A, long long int> {
 
    public:
@@ -41,16 +41,16 @@ class DgDiscRF : public DgRF<A, long long int> {
 
          public:
 
-            DgQuantConverter (const DgRF<B, DB>& fromFrame, 
+            DgQuantConverter (const DgRF<B, DB>& fromFrame,
                               const DgDiscRF<A, B, DB>& toFrame)
-               : DgConverter<B, DB, A, long long int> 
-                       (static_cast< const DgRF<B, DB>& >(fromFrame), 
+               : DgConverter<B, DB, A, long long int>
+                       (static_cast< const DgRF<B, DB>& >(fromFrame),
                         static_cast< const DgRF<A, long long int>& >(toFrame)) { }
 
             virtual A convertTypedAddress (const B& addIn) const
-              { return 
+              { return
                    static_cast<const DgDiscRF<A, B, DB>&>(
-                                  this->toFrame()).quantify(addIn); 
+                                  this->toFrame()).quantify(addIn);
 	      }
 
       };
@@ -64,9 +64,9 @@ class DgDiscRF : public DgRF<A, long long int> {
                : DgConverter<A, long long int, B, DB> (fromFrame, toFrame) { }
 
             virtual B convertTypedAddress (const A& addIn) const
-             { return 
+             { return
                   static_cast<const DgDiscRF<A, B, DB>&>(
-                                         this->fromFrame()).invQuantify(addIn); 
+                                         this->fromFrame()).invQuantify(addIn);
 	     }
 
       };
@@ -76,28 +76,28 @@ class DgDiscRF : public DgRF<A, long long int> {
                 long double rIn = 1.0L, long double cIn = 1.0L, long double areaIn = 1.0L)
         : DgRF<A, long long int> (networkIn, nameIn), backFrame_ (&backFrameIn),
           e_ (eIn), r_ (rIn), c_ (cIn), area_ (areaIn)
-        { new DgQuantConverter(backFrame(), *this);
-          new DgInvQuantConverter(*this, backFrame()); }
+        { DgQuantConverter(backFrame(), *this);
+          DgInvQuantConverter(*this, backFrame()); }
 
-      DgDiscRF (const DgDiscRF<A, B, DB>& rf) : DgRF<A, long long int> (rf), 
+      DgDiscRF (const DgDiscRF<A, B, DB>& rf) : DgRF<A, long long int> (rf),
           backFrame_ (&rf.backFrame()), e_ (rf.e()), r_ (rf.r()),
           c_ (rf.c()), area_ (rf.area())
-        { new DgQuantConverter(backFrame(), *this);
-          new DgInvQuantConverter(*this, backFrame()); 
-	}
+        { DgQuantConverter(backFrame(), *this);
+          DgInvQuantConverter(*this, backFrame());
+	   }
 
       DgDiscRF& operator= (const DgDiscRF<A, B, DB>& rf)
-          { 
+          {
              if (&rf != this)
              {
-                DgRF<A, long long int>::operator=(rf); 
+                DgRF<A, long long int>::operator=(rf);
                 e_ = rf.e();
                 r_ = rf.r();
                 c_ = rf.c();
                 area_ = rf.area();
                 backFrame_ = &rf.backFrame();
              }
-             return *this; 
+             return *this;
           }
 
       // get methods
@@ -117,22 +117,22 @@ class DgDiscRF : public DgRF<A, long long int> {
       void setArea (long double areaIn) { area_ = areaIn; }
 
       // misc methods
-      
+
       virtual string dist2str (const long long int& dist) const { return dgg::util::to_string(dist); }
       virtual long double dist2dbl (const long long int& dist) const { return (long double) dist; }
-      virtual unsigned long long int dist2int (const long long int& dist) const 
+      virtual unsigned long long int dist2int (const long long int& dist) const
                          { return static_cast<unsigned long long int>(dist); }
 
       virtual void setPoint (const DgLocation& loc, DgLocation& point) const;
 
       virtual void setPoint (const DgLocation& loc, const DgRFBase& rf,
-                                                   DgLocation& point) const; 
-      virtual void setPoint (const A& add, const DgRFBase& rf, 
+                                                   DgLocation& point) const;
+      virtual void setPoint (const A& add, const DgRFBase& rf,
                              DgLocation& point) const
                { setAddPoint(add, point); rf.convert(&point); }
 
       virtual void setPoint (const A& add, DgLocation& pt) const
-                    { pt.clearAddress(); backFrame().convert(&pt); 
+                    { pt.clearAddress(); backFrame().convert(&pt);
                       setAddPoint(add, pt); }
 
       virtual void setVertices (const DgLocation& loc, DgPolygon& vec) const;
@@ -140,17 +140,17 @@ class DgDiscRF : public DgRF<A, long long int> {
       virtual void setVertices (const DgLocation& loc, const DgRFBase& rf,
                                                        DgPolygon& vec) const;
 
-      virtual void setVertices (const A& add, const DgRFBase& rf, 
+      virtual void setVertices (const A& add, const DgRFBase& rf,
                                                         DgPolygon& vec) const
                { setAddVertices(add, vec); rf.convert(vec); }
 
       virtual void setVertices  (const A& add, DgPolygon& vec) const
-               { vec.clearAddress(); backFrame().convert(vec); 
+               { vec.clearAddress(); backFrame().convert(vec);
                  setAddVertices(add, vec); }
 
       virtual void setNeighbors (const DgLocation& loc, DgLocVector& vec) const;
 
-      virtual void setNeighbors (const A& add, const DgRFBase& rf, 
+      virtual void setNeighbors (const A& add, const DgRFBase& rf,
                                                         DgLocVector& vec) const
                { setAddNeighbors(add, vec); rf.convert(vec); }
 
@@ -184,7 +184,7 @@ class DgDiscRF : public DgRF<A, long long int> {
       // second order boundary neighbors (for aperture 7 hex grids only)
       virtual void setNeighborsBdry2 (const DgLocation& loc, DgLocVector& vec) const;
 
-      virtual void setNeighborsBdry2 (const A& add, const DgRFBase& rf, 
+      virtual void setNeighborsBdry2 (const A& add, const DgRFBase& rf,
                                                         DgLocVector& vec) const
                { setAddNeighborsBdry2(add, vec); rf.convert(vec); }
 
@@ -205,13 +205,13 @@ class DgDiscRF : public DgRF<A, long long int> {
       }
 
       // remind users of the pure virtual functions remaining from above
-      
+
       virtual string add2str (const A& add) const = 0;
       virtual string add2str (const A& add, char delimiter) const = 0;
 
       virtual long long int dist (const A& add1, const A& add2) const = 0;
 
-      virtual const char* str2add (A* add, const char* str, char delimiter) 
+      virtual const char* str2add (A* add, const char* str, char delimiter)
                                                                       const = 0;
 
       virtual const A& undefAddress (void) const = 0;

--- a/src/lib/dglib/lib/DgDmdD4Grid2DS.cpp
+++ b/src/lib/dglib/lib/DgDmdD4Grid2DS.cpp
@@ -34,13 +34,13 @@
 #include "DgDmdD8Grid2D.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-DgDmdD4Grid2DS::DgDmdD4Grid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgDmdD4Grid2DS::DgDmdD4Grid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
                const string& nameIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, 
-                       isCongruentIn, isAlignedIn, nameIn) 
-{ 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn,
+                       isCongruentIn, isAlignedIn, nameIn)
+{
    // determine the radix
    radix_ = static_cast<int>(sqrt(static_cast<float>(aperture())));
    if (static_cast<unsigned int>(radix() * radix()) != aperture())
@@ -64,7 +64,7 @@ DgDmdD4Grid2DS::DgDmdD4Grid2DS (DgRFNetwork& networkIn,
    if (isCongruent())
    {
       //trans = DgDVec2D(-0.5, -0.5);
-      trans = 
+      trans =
         DgDVec2D(-1.0 * DgDmdD4Grid2D::xOff(), -1.0 * DgDmdD4Grid2D::yOff());
    }
    else if (isAligned())
@@ -91,11 +91,11 @@ DgDmdD4Grid2DS::DgDmdD4Grid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0, 
-                                    trans); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0,
+                                    trans);
 
       (*grids_)[i] = new DgDmdD4Grid2D(network(), *ccRF, newName);
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                      (*this, *(grids()[i]), i);
 
       fac *= radix();
@@ -104,7 +104,7 @@ DgDmdD4Grid2DS::DgDmdD4Grid2DS (DgRFNetwork& networkIn,
 } // DgDmdD4Grid2DS::DgDmdD4Grid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgDmdD4Grid2DS::DgDmdD4Grid2DS (const DgDmdD4Grid2DS& rf) 
+DgDmdD4Grid2DS::DgDmdD4Grid2DS (const DgDmdD4Grid2DS& rf)
   : DgDiscRFS2D (rf)
 {
    report("DgDmdD4Grid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -129,8 +129,8 @@ DgDmdD4Grid2DS::operator= (const DgDmdD4Grid2DS& rf)
 } // DgDmdD4Grid2DS& DgDmdD4Grid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                                DgLocVector& vec) const
 {
 //cout << "   setAddParents: " << add << endl;
@@ -163,10 +163,10 @@ DgDmdD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
       {
          bool found = false;
 
-         for (int j = 0; j < vec.size(); j++) 
+         for (int j = 0; j < vec.size(); j++)
          {
 //cout << "  " << i << " " << j << " " << (*verts)[i] << " " << vec[j];
-            if ((*verts)[i] == vec[j]) 
+            if ((*verts)[i] == vec[j])
             {
 //cout << " YES" << endl;
                found = true;
@@ -174,7 +174,7 @@ DgDmdD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
             }
 //cout << " NO" << endl;
          }
-         
+
          if (!found) vec.push_back((*verts)[i]);
       }
 //cout << "   parents: " << vec << endl;
@@ -185,8 +185,8 @@ DgDmdD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgDmdD4Grid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -199,7 +199,7 @@ DgDmdD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
          for (int j = 0; j < radix(); j++)
          {
             v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j), 
+             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j),
                                add.res() + 1)));
          }
       }
@@ -214,12 +214,12 @@ DgDmdD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
 
       delete tmpLoc;
    }
-   
+
 } // void DgDmdD4Grid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -246,8 +246,8 @@ DgDmdD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgDmdD4Grid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD4Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD4Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);

--- a/src/lib/dglib/lib/DgDmdD8Grid2DS.cpp
+++ b/src/lib/dglib/lib/DgDmdD8Grid2DS.cpp
@@ -33,13 +33,13 @@
 #include "DgDmdD8Grid2DS.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-DgDmdD8Grid2DS::DgDmdD8Grid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgDmdD8Grid2DS::DgDmdD8Grid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
                const string& nameIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, 
-                       isCongruentIn, isAlignedIn, nameIn) 
-{ 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn,
+                       isCongruentIn, isAlignedIn, nameIn)
+{
    // determine the radix
 
    radix_ = static_cast<int>(sqrt(static_cast<float>(aperture())));
@@ -57,7 +57,7 @@ DgDmdD8Grid2DS::DgDmdD8Grid2DS (DgRFNetwork& networkIn,
    }
 
    // do the grids
-   
+
    long double fac = 1;
 
    DgDVec2D trans;
@@ -89,11 +89,11 @@ DgDmdD8Grid2DS::DgDmdD8Grid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0, 
-                                    trans); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0,
+                                    trans);
 
       (*grids_)[i] = new DgDmdD8Grid2D(network(), *ccRF, newName);
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[i]), i);
 
       fac *= radix();
@@ -102,7 +102,7 @@ DgDmdD8Grid2DS::DgDmdD8Grid2DS (DgRFNetwork& networkIn,
 } // DgDmdD8Grid2DS::DgDmdD8Grid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgDmdD8Grid2DS::DgDmdD8Grid2DS (const DgDmdD8Grid2DS& rf) 
+DgDmdD8Grid2DS::DgDmdD8Grid2DS (const DgDmdD8Grid2DS& rf)
   : DgDiscRFS2D (rf)
 {
    report("DgDmdD8Grid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -127,8 +127,8 @@ DgDmdD8Grid2DS::operator= (const DgDmdD8Grid2DS& rf)
 } // DgDmdD8Grid2DS& DgDmdD8Grid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                                DgLocVector& vec) const
 {
 //cout << "   setAddParents: " << add << endl;
@@ -161,10 +161,10 @@ DgDmdD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
       {
          bool found = false;
 
-         for (int j = 0; j < vec.size(); j++) 
+         for (int j = 0; j < vec.size(); j++)
          {
 //cout << "  " << i << " " << j << " " << (*verts)[i] << " " << vec[j];
-            if ((*verts)[i] == vec[j]) 
+            if ((*verts)[i] == vec[j])
             {
 //cout << " YES" << endl;
                found = true;
@@ -172,7 +172,7 @@ DgDmdD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
             }
 //cout << " NO" << endl;
          }
-         
+
          if (!found) vec.push_back((*verts)[i]);
       }
 //cout << "   parents: " << vec << endl;
@@ -183,8 +183,8 @@ DgDmdD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgDmdD8Grid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -197,7 +197,7 @@ DgDmdD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
          for (int j = 0; j < radix(); j++)
          {
             v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j), 
+             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j),
                                add.res() + 1)));
          }
       }
@@ -212,12 +212,12 @@ DgDmdD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
 
       delete tmpLoc;
    }
-   
+
 } // void DgDmdD8Grid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -237,8 +237,8 @@ DgDmdD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgDmdD8Grid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgDmdD8Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgDmdD8Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);

--- a/src/lib/dglib/lib/DgGeoSphRF.cpp
+++ b/src/lib/dglib/lib/DgGeoSphRF.cpp
@@ -35,7 +35,7 @@ long double DgGeoSphRF::earthRadiusKM_ = DEFAULT_RADIUS_KM;
 long double DgGeoSphRF::icosaEdgeRads_ = M_ATAN2;
 long double DgGeoSphRF::icosaEdgeDegs_ = icosaEdgeRads_ * M_180_PI;
 long double DgGeoSphRF::icosaEdgeKM_ = icosaEdgeRads_ * earthRadiusKM_;
-long double DgGeoSphRF::totalAreaKM_ = 
+long double DgGeoSphRF::totalAreaKM_ =
                       4.0L * M_PI * earthRadiusKM_ * earthRadiusKM_;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,7 +85,7 @@ DgGeoSphRF::densify (DgPolygon& p, long double maxDist, bool rads)
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-DgGeoCoord 
+DgGeoCoord
 DgGeoSphRF::midPoint (const DgGeoCoord& p1, const DgGeoCoord& p2)
 /*
    Return midpoint of great circle connecting two points.
@@ -100,15 +100,15 @@ DgGeoSphRF::midPoint (const DgGeoCoord& p1, const DgGeoCoord& p2)
    pp2.lat = p2.lat();
 
    GeoCoord ans = GCmidpoint(pp1, pp2);
-   
+
    return DgGeoCoord(ans.lon, ans.lat);
 
 } // DgGeoCoord DgGeoSphRF::midPoint
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-long double 
-DgGeoSphRF::azimuth (const DgGeoCoord& p1, const DgGeoCoord& p2, 
+long double
+DgGeoSphRF::azimuth (const DgGeoCoord& p1, const DgGeoCoord& p2,
                      bool returnRads)
 /*
    Return azimuth from p1 to p2.
@@ -123,7 +123,7 @@ DgGeoSphRF::azimuth (const DgGeoCoord& p1, const DgGeoCoord& p2,
    pp2.lat = p2.lat();
 
    long double ans = Azimuth(pp1, pp2);
-   
+
    if (!returnRads) ans *= M_180_PI;
    return ans;
 
@@ -131,11 +131,11 @@ DgGeoSphRF::azimuth (const DgGeoCoord& p1, const DgGeoCoord& p2,
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-DgGeoCoord 
+DgGeoCoord
 DgGeoSphRF::travelGC (const DgGeoCoord& p0, long double distance, long double azimuth,
                       bool inputRads)
 /*
-   Return point that is distance from p0 along azimuth. 
+   Return point that is distance from p0 along azimuth.
 
    Works by calling Lian Song's routine Azimuth.
 */
@@ -151,7 +151,7 @@ DgGeoSphRF::travelGC (const DgGeoCoord& p0, long double distance, long double az
    }
 
    GeoCoord ans = GCdaz(pp0, distance, azimuth);
-   
+
    return DgGeoCoord(ans.lon, ans.lat);
 
 } // long double DgGeoSphRF::azimuth
@@ -160,6 +160,5 @@ DgGeoSphRF::travelGC (const DgGeoCoord& p0, long double distance, long double az
 DgGeoSphDegRF::DgGeoSphDegRF (const DgGeoSphRF& geoRFin, const string& nameIn)
          : DgContCartRF (geoRFin.network(), nameIn), geoRF_ (geoRFin)
 {
-   new DgDegRadConverter(geoRFin, *this);
+   DgDegRadConverter(geoRFin, *this);
 }
-

--- a/src/lib/dglib/lib/DgHexC2Grid2D.cpp
+++ b/src/lib/dglib/lib/DgHexC2Grid2D.cpp
@@ -46,7 +46,7 @@ DgHexC2Grid2D::DgHexC2Grid2D (DgRFNetwork& networkIn,
                               nameIn + string("SurBF"));
 
    // version 6.4 and previous rotated by 30.0L
-   new Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, -30.0L);
+   Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, -30.0L);
    surrogate_ = new DgHexC1Grid2D(network(), *surCCRF, nameIn + string("Sur"));
 
    // create the substrate hex grid: a class I hex one aperture 3 resolution
@@ -55,7 +55,7 @@ DgHexC2Grid2D::DgHexC2Grid2D (DgRFNetwork& networkIn,
    DgContCartRF* subCCRF = new DgContCartRF(network(), 
                               nameIn + string("SubBF"));
 
-   new Dg2WayContAffineConverter(backFrame(), *subCCRF, M_SQRT3);
+   Dg2WayContAffineConverter(backFrame(), *subCCRF, M_SQRT3);
    substrate_ = new DgHexC1Grid2D(network(), *subCCRF, nameIn + string("Sub"));
 
 } // DgHexC2Grid2D::DgHexC2Grid2D

--- a/src/lib/dglib/lib/DgHexC3Grid2D.cpp
+++ b/src/lib/dglib/lib/DgHexC3Grid2D.cpp
@@ -51,10 +51,10 @@ DgHexC3Grid2D::DgHexC3Grid2D (DgRFNetwork& networkIn,
    if (!isClassI)
       rotDegs *= -30.0L;
 
-   new Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, rotDegs);
+   Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, rotDegs);
    surrogate_ = new DgHexC1Grid2D(network(), *surCCRF, nameIn + string("Sur"));
 */
-   new Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, rotDegs);
+   Dg2WayContAffineConverter(backFrame(), *surCCRF, 1.0L, rotDegs);
    if (isClassI)
       surrogate_ = new DgHexC1Grid2D(network(), *surCCRF, nameIn + string("Sur"));
    else

--- a/src/lib/dglib/lib/DgHexGrid2DS.cpp
+++ b/src/lib/dglib/lib/DgHexGrid2DS.cpp
@@ -25,8 +25,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <cmath>
-
 #include "DgContCartRF.h"
 #include "DgDiscRF.h"
 #include "DgHexC1Grid2D.h"
@@ -34,19 +32,22 @@
 #include "DgHexC3Grid2D.h"
 #include "DgHexGrid2DS.h"
 
+#include <cmath>
+#include <memory>
+
 static const string& emptyStr = "";
 
 ////////////////////////////////////////////////////////////////////////////////
-DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
-               const DgApSeq& apSeqIn, const string& nameIn) 
+DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
+               const DgApSeq& apSeqIn, const string& nameIn)
         : DgDiscRFS2D (networkIn, backFrameIn, nResIn, 4,
-                       //apSeqIn.getAperture(apSeqIn.lastRes()).aperture(), 
-                       0, 1, nameIn), 
+                       //apSeqIn.getAperture(apSeqIn.lastRes()).aperture(),
+                       0, 1, nameIn),
           apSeq_ (apSeqIn),
           // these are deprecated and not used by this constructor
           isMixed43_ (0), numAp4_ (0), isSuperfund_ (0), isApSeq_ (0)
-{ 
+{
    //frequency_ = sqrt((long double) aperture());
 
    // do the grids
@@ -66,8 +67,8 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, M_ZERO, 
-                                    DgDVec2D(M_ZERO, M_ZERO)); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, M_ZERO,
+                                    DgDVec2D(M_ZERO, M_ZERO));
 
       if (isClassIII)
          (*grids_)[r] = new DgHexC3Grid2D(network(), *ccRF, isClassI, newName);
@@ -79,7 +80,7 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
             (*grids_)[r] = new DgHexC2Grid2D(network(), *ccRF, newName);
       }
 
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[r]), r);
       // setup for next res
       if (r < apSeq().lastRes())
@@ -107,17 +108,17 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
 
 ////////////////////////////////////////////////////////////////////////////////
 // this constructor is deprecated
-DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
-               const string& nameIn, bool isMixed43In, int numAp4In, 
+               const string& nameIn, bool isMixed43In, int numAp4In,
                bool isSuperfundIn, bool isApSeqIn, const DgApSeq& apSeqIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, isCongruentIn, 
-                       isAlignedIn, nameIn), 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, isCongruentIn,
+                       isAlignedIn, nameIn),
           apSeq_ (apSeqIn),
           isMixed43_ (isMixed43In), numAp4_ (numAp4In), isSuperfund_ (isSuperfundIn),
           isApSeq_ (isApSeqIn)
-{ 
+{
    if (isApSeq())
       report("DgHexGrid2DS::DgHexGrid2DS() isApSeq should be false in this constructor",
        DgBase::Fatal);
@@ -157,13 +158,13 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, M_ZERO, 
-                                    DgDVec2D(M_ZERO, M_ZERO)); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, M_ZERO,
+                                    DgDVec2D(M_ZERO, M_ZERO));
 
       bool isClassI;
       if (!isMixed43())
       {
-         if (aperture() == 4) 
+         if (aperture() == 4)
             isClassI = true;
          else // ap 3
             isClassI = !(i % 2);
@@ -185,7 +186,7 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
          (*grids_)[i] = new DgHexC2Grid2D(network(), *ccRF, newName);
       }
 
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[i]), i);
       if (isMixed43())
       {
@@ -203,7 +204,7 @@ DgHexGrid2DS::DgHexGrid2DS (DgRFNetwork& networkIn,
 } // DgHexGrid2DS::DgHexGrid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgHexGrid2DS::DgHexGrid2DS (const DgHexGrid2DS& rf) 
+DgHexGrid2DS::DgHexGrid2DS (const DgHexGrid2DS& rf)
   : DgDiscRFS2D (rf), apSeq_ (DgApSeq::defaultApSeq)
 {
    report("DgHexGrid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -214,8 +215,8 @@ DgHexGrid2DS::DgHexGrid2DS (const DgHexGrid2DS& rf)
 DgHexGrid2DS::~DgHexGrid2DS (void)
 {
 /*
-   for (unsigned long i = 0; i < grids().size(); i++) 
-    delete (*grids_)[i]; 
+   for (unsigned long i = 0; i < grids().size(); i++)
+    delete (*grids_)[i];
 
    delete grids_;
 */
@@ -233,8 +234,8 @@ DgHexGrid2DS::operator= (const DgHexGrid2DS& rf)
 } // DgHexGrid2DS& DgHexGrid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgHexGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                              DgLocVector& vec) const
 {
    DgPolygon verts;
@@ -280,7 +281,7 @@ DgHexGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
          DgDVec2D pt2 = *(grids()[add.res()]->backFrame().getAddress(
                                               verts[(i + 1) % verts.size()]));
 
-         DgLocation* tmpLoc = 
+         DgLocation* tmpLoc =
             grids()[add.res()]->backFrame().makeLocation(
                                               DgDVec2D::midPoint(pt1, pt2));
 
@@ -312,8 +313,8 @@ DgHexGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgHexGrid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgHexGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    DgLocVector verts;
@@ -326,8 +327,8 @@ DgHexGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgHexGrid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgHexGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    DgPolygon verts;
@@ -373,7 +374,7 @@ DgHexGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
          DgDVec2D pt2 = *(grids()[add.res()]->backFrame().getAddress(
                                               verts[(i + 1) % verts.size()]));
 
-         DgLocation* tmpLoc = 
+         DgLocation* tmpLoc =
             grids()[add.res()]->backFrame().makeLocation(
                                               DgDVec2D::midPoint(pt1, pt2));
 
@@ -405,8 +406,8 @@ DgHexGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgHexGrid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexGrid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgHexGrid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);

--- a/src/lib/dglib/lib/DgHexIDGGS.cpp
+++ b/src/lib/dglib/lib/DgHexIDGGS.cpp
@@ -35,25 +35,25 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 DgHexIDGGS::DgHexIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
-                  const DgGeoCoord& vert0, long double azDegs, 
-                  unsigned int aperture, int nRes, 
-                  const string& name, const string& projType, 
+                  const DgGeoCoord& vert0, long double azDegs,
+                  unsigned int aperture, int nRes,
+                  const string& name, const string& projType,
                   const DgApSeq& apSeq, bool isApSeq,
                   bool isMixed43, int numAp4, bool isSuperfund)
-        : DgIDGGS (network, backFrame, vert0, azDegs, aperture, nRes, 
+        : DgIDGGS (network, backFrame, vert0, azDegs, aperture, nRes,
                        "HEXAGON", name, projType, isMixed43, numAp4,
                        isSuperfund, isApSeq, apSeq),
           apSeq_ (apSeq)
 {
    if (!isApSeq) // need to build the apSeq
-   {  
+   {
       int r;
-         
+
       if (isMixed43)
-      {  
+      {
          for (r = 0; r < numAp4; r++)
             apSeq_.addAperture(DgAperture(4));
-            
+
          for (; r < nRes - 1; r++)
             apSeq_.addAperture(DgAperture(3));
       }
@@ -61,11 +61,11 @@ DgHexIDGGS::DgHexIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
          for (r = 0; r < nRes - 1; r++)
             apSeq_.addAperture(DgAperture((aperture == 3) ? 3 : 4));
    }
-         
+
    if (nRes > apSeq_.nRes() + 1) // remember +1 resolution for res 0
       report("DgHexIDGGS::DgHexIDGGS res " + dgg::util::to_string(nRes) +
              " exceeds aperture sequence string length", DgBase::Fatal);
-   
+
    undefLoc_ = makeLocation(undefAddress());
    isAligned_ = 1;
    isCongruent_ = 0;
@@ -80,14 +80,15 @@ DgHexIDGGS::DgHexIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
    {
       int ap = apSeq_.getAperture(r).aperture();
 
-      (*grids_)[r] = new DgHexIDGG(*this, ap, r, 
+      (*grids_)[r] = new DgHexIDGG(*this, ap, r,
                                    name + dgg::util::to_string(r, 2));
    //cout << "========================\nRES " << r << ": " << hexIdgg(r);
    }
 
-   for (int r = 0; r < nRes; r++)
-      new Dg2WayResAddConverter<DgQ2DICoord, DgGeoCoord, long double> 
+   for (int r = 0; r < nRes; r++){
+      Dg2WayResAddConverter<DgQ2DICoord, DgGeoCoord, long double>
                                                    (*this, *(grids()[r]), r);
+   }
 
 } // DgHexIDGGS::DgHexIDGGS
 
@@ -100,8 +101,8 @@ DgHexIDGGS::DgHexIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
 ////////////////////////////////////////////////////////////////////////////////
 DgHexIDGGS::~DgHexIDGGS (void)
 {
-   for (unsigned long i = 0; i < grids().size(); i++) 
-    delete (*grids_)[i]; 
+   for (unsigned long i = 0; i < grids().size(); i++)
+    delete (*grids_)[i];
 
    delete grids_;
 
@@ -109,8 +110,8 @@ DgHexIDGGS::~DgHexIDGGS (void)
 */
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexIDGGS::setAddParents (const DgResAdd<DgQ2DICoord>& add, 
+void
+DgHexIDGGS::setAddParents (const DgResAdd<DgQ2DICoord>& add,
                              DgLocVector& vec) const
 {
    DgPolygon verts;
@@ -142,8 +143,8 @@ DgHexIDGGS::setAddParents (const DgResAdd<DgQ2DICoord>& add,
 } // void DgHexIDGGS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexIDGGS::setAddInteriorChildren (const DgResAdd<DgQ2DICoord>& add, 
+void
+DgHexIDGGS::setAddInteriorChildren (const DgResAdd<DgQ2DICoord>& add,
                                         DgLocVector& vec) const
 {
    // single center hex at next res
@@ -157,8 +158,8 @@ DgHexIDGGS::setAddInteriorChildren (const DgResAdd<DgQ2DICoord>& add,
 } // void DgHexIDGGS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexIDGGS::setAddBoundaryChildren (const DgResAdd<DgQ2DICoord>& add, 
+void
+DgHexIDGGS::setAddBoundaryChildren (const DgResAdd<DgQ2DICoord>& add,
                                         DgLocVector& vec) const
 {
    const DgHexIDGG& dgg = hexIdgg(add.res());
@@ -167,7 +168,7 @@ DgHexIDGGS::setAddBoundaryChildren (const DgResAdd<DgQ2DICoord>& add,
    // the neighbors of the center hex at next res
    DgLocation* centerLoc = dgg.makeLocation(add.address());
    dggr.convert(centerLoc);
-   const DgQ2DICoord& centerAdd = 
+   const DgQ2DICoord& centerAdd =
        *dggr.getAddress(*centerLoc);
 
    dggr.setAddNeighbors(centerAdd, vec);
@@ -177,8 +178,8 @@ DgHexIDGGS::setAddBoundaryChildren (const DgResAdd<DgQ2DICoord>& add,
 } // void DgHexIDGGS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexIDGGS::setAddBoundary2Children (const DgResAdd<DgQ2DICoord>& add, 
+void
+DgHexIDGGS::setAddBoundary2Children (const DgResAdd<DgQ2DICoord>& add,
                                         DgLocVector& vec) const
 {
    const DgHexIDGG& dgg = hexIdgg(add.res());
@@ -189,7 +190,7 @@ DgHexIDGGS::setAddBoundary2Children (const DgResAdd<DgQ2DICoord>& add,
    // the neighbors of the center hex at next res
    DgLocation* centerLoc = dgg.makeLocation(add.address());
    dggr.convert(centerLoc);
-   const DgQ2DICoord& centerAdd = 
+   const DgQ2DICoord& centerAdd =
        *dggr.getAddress(*centerLoc);
 
    dggr.setAddNeighborsBdry2(centerAdd, vec);
@@ -199,8 +200,8 @@ DgHexIDGGS::setAddBoundary2Children (const DgResAdd<DgQ2DICoord>& add,
 } // void DgHexIDGGS::setAddBoundary2Children
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgHexIDGGS::setAddAllChildren (const DgResAdd<DgQ2DICoord>& add, 
+void
+DgHexIDGGS::setAddAllChildren (const DgResAdd<DgQ2DICoord>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);
@@ -217,4 +218,3 @@ DgHexIDGGS::setAddAllChildren (const DgResAdd<DgQ2DICoord>& add,
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-

--- a/src/lib/dglib/lib/DgIDGGS.cpp
+++ b/src/lib/dglib/lib/DgIDGGS.cpp
@@ -36,9 +36,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 const DgIDGGS*
 DgIDGGS::makeRF (DgRFNetwork& network, const DgGeoSphRF& backFrame,
-          const DgGeoCoord& vert0, long double azDegs, unsigned int apertureIn, 
+          const DgGeoCoord& vert0, long double azDegs, unsigned int apertureIn,
           int nRes, const string& gridTopo, const string& name,
-          const string& projTypeIn, bool isMixed43In, int numAp4In, 
+          const string& projTypeIn, bool isMixed43In, int numAp4In,
           bool isSuperfundIn, bool isApSeqIn, const DgApSeq& apSeqIn)
 {
    if (isApSeqIn)
@@ -58,11 +58,11 @@ DgIDGGS::makeRF (DgRFNetwork& network, const DgGeoSphRF& backFrame,
       if (defaultName) {
          if (!isMixed43In)
          {
-            if (apertureIn == 4) 
+            if (apertureIn == 4)
                theName = projTypeIn + string("4H");
-            else if (apertureIn == 3) 
+            else if (apertureIn == 3)
                theName = projTypeIn + string("3H");
-            else 
+            else
                report(apErrStr, DgBase::Fatal);
          }
          else
@@ -77,7 +77,7 @@ DgIDGGS::makeRF (DgRFNetwork& network, const DgGeoSphRF& backFrame,
       if (apertureIn == 4)
       {
          if (defaultName) theName = projTypeIn + string("4D");
-         dg0 = new DgIDGGS4D(network, backFrame, vert0, azDegs, nRes, 
+         dg0 = new DgIDGGS4D(network, backFrame, vert0, azDegs, nRes,
                        theName, projTypeIn);
       }
       else
@@ -88,7 +88,7 @@ DgIDGGS::makeRF (DgRFNetwork& network, const DgGeoSphRF& backFrame,
       if (apertureIn == 4)
       {
          if (defaultName) theName = projTypeIn + string("4T");
-         dg0 = new DgIDGGS4T(network, backFrame, vert0, azDegs, nRes, 
+         dg0 = new DgIDGGS4T(network, backFrame, vert0, azDegs, nRes,
                        theName, projTypeIn);
       }
       else
@@ -107,17 +107,17 @@ DgIDGGS::makeRF (DgRFNetwork& network, const DgGeoSphRF& backFrame,
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 DgIDGGS::DgIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
-                  const DgGeoCoord& vert0, long double azDegs, 
-                  unsigned int aperture, int nRes, const string& gridTopo, 
-                  const string& name, const string& projType, bool isMixed43, 
+                  const DgGeoCoord& vert0, long double azDegs,
+                  unsigned int aperture, int nRes, const string& gridTopo,
+                  const string& name, const string& projType, bool isMixed43,
                   int numAp4, bool isSuperfund, bool isApSeq,
                   const DgApSeq& apSeq)
-        : DgIDGGSBase (network, backFrame, vert0, azDegs, nRes, aperture, name, 
+        : DgIDGGSBase (network, backFrame, vert0, azDegs, nRes, aperture, name,
                        gridTopo, projType, !(isMixed43 || isApSeq)),
           numAp4_ (numAp4), isSuperfund_ (isSuperfund), isApSeq_ (isApSeq),
           apSeq_ (apSeq)
 {
-   
+
    undefLoc_ = makeLocation(undefAddress());
 
    // create the DGGs for non-hex DGGS; the grids for hex DGGS are created
@@ -136,7 +136,7 @@ DgIDGGS::DgIDGGS (DgRFNetwork& network, const DgGeoSphRF& backFrame,
                "DDG", gridTopo, projType, isMixed43, numAp4, isSuperfund,
                actualRes2sfRes(i));
 
-         new Dg2WayResAddConverter<DgQ2DICoord, DgGeoCoord, long double> 
+         Dg2WayResAddConverter<DgQ2DICoord, DgGeoCoord, long double>
                                                    (*this, *(grids()[i]), i);
 
          isAligned_ = idgg(0).isAligned();

--- a/src/lib/dglib/lib/DgSqrD4Grid2DS.cpp
+++ b/src/lib/dglib/lib/DgSqrD4Grid2DS.cpp
@@ -31,13 +31,13 @@
 #include "DgSqrD8Grid2D.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-DgSqrD4Grid2DS::DgSqrD4Grid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgSqrD4Grid2DS::DgSqrD4Grid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
                const string& nameIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, 
-                       isCongruentIn, isAlignedIn, nameIn) 
-{ 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn,
+                       isCongruentIn, isAlignedIn, nameIn)
+{
    // determine the radix
 
    radix_ = static_cast<int>(sqrt(static_cast<float>(aperture())));
@@ -55,7 +55,7 @@ DgSqrD4Grid2DS::DgSqrD4Grid2DS (DgRFNetwork& networkIn,
    }
 
    // do the grids
-  
+
    long double fac = 1;
 
    DgDVec2D trans;
@@ -81,11 +81,11 @@ DgSqrD4Grid2DS::DgSqrD4Grid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0, 
-                                    trans); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0,
+                                    trans);
 
       (*grids_)[i] = new DgSqrD4Grid2D(network(), *ccRF, newName);
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[i]), i);
 
       fac *= radix();
@@ -94,7 +94,7 @@ DgSqrD4Grid2DS::DgSqrD4Grid2DS (DgRFNetwork& networkIn,
 } // DgSqrD4Grid2DS::DgSqrD4Grid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgSqrD4Grid2DS::DgSqrD4Grid2DS (const DgSqrD4Grid2DS& rf) 
+DgSqrD4Grid2DS::DgSqrD4Grid2DS (const DgSqrD4Grid2DS& rf)
   : DgDiscRFS2D (rf)
 {
    report("DgSqrD4Grid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -104,8 +104,8 @@ DgSqrD4Grid2DS::DgSqrD4Grid2DS (const DgSqrD4Grid2DS& rf)
 ////////////////////////////////////////////////////////////////////////////////
 DgSqrD4Grid2DS::~DgSqrD4Grid2DS (void)
 {
-   for (unsigned long i = 0; i < grids().size(); i++) 
-    delete (*grids_)[i]; 
+   for (unsigned long i = 0; i < grids().size(); i++)
+    delete (*grids_)[i];
 
    delete grids_;
 } // DgSqrD4Grid2DS::~DgSqrD4Grid2DS
@@ -121,8 +121,8 @@ DgSqrD4Grid2DS::operator= (const DgSqrD4Grid2DS& rf)
 } // DgSqrD4Grid2DS& DgSqrD4Grid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                                DgLocVector& vec) const
 {
 //cout << "   setAddParents: " << add << endl;
@@ -155,10 +155,10 @@ DgSqrD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
       {
          bool found = false;
 
-         for (int j = 0; j < vec.size(); j++) 
+         for (int j = 0; j < vec.size(); j++)
          {
 //cout << "  " << i << " " << j << " " << (*verts)[i] << " " << vec[j];
-            if ((*verts)[i] == vec[j]) 
+            if ((*verts)[i] == vec[j])
             {
 //cout << " YES" << endl;
                found = true;
@@ -166,7 +166,7 @@ DgSqrD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
             }
 //cout << " NO" << endl;
          }
-         
+
          if (!found) vec.push_back((*verts)[i]);
       }
 //cout << "   parents: " << vec << endl;
@@ -177,8 +177,8 @@ DgSqrD4Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgSqrD4Grid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -191,7 +191,7 @@ DgSqrD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
          for (int j = 0; j < radix(); j++)
          {
             v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j), 
+             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j),
                                add.res() + 1)));
          }
       }
@@ -206,12 +206,12 @@ DgSqrD4Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
 
       delete tmpLoc;
    }
-   
+
 } // void DgSqrD4Grid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -224,7 +224,7 @@ DgSqrD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 
       // D8 neighbors is what we want
 
-      DgSqrD8Grid2D d8(network(), grids()[add.res() + 1]->backFrame(), 
+      DgSqrD8Grid2D d8(network(), grids()[add.res() + 1]->backFrame(),
                        "dummyD8");
       d8.convert(tmpLoc);
       d8.setNeighbors(*tmpLoc, vec);
@@ -238,8 +238,8 @@ DgSqrD4Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgSqrD4Grid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD4Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD4Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);

--- a/src/lib/dglib/lib/DgSqrD8Grid2DS.cpp
+++ b/src/lib/dglib/lib/DgSqrD8Grid2DS.cpp
@@ -30,13 +30,13 @@
 #include "DgSqrD8Grid2DS.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-DgSqrD8Grid2DS::DgSqrD8Grid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgSqrD8Grid2DS::DgSqrD8Grid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
                const string& nameIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, 
-                       isCongruentIn, isAlignedIn, nameIn) 
-{ 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn,
+                       isCongruentIn, isAlignedIn, nameIn)
+{
    // determine the radix
 
    radix_ = static_cast<int>(sqrt(static_cast<float>(aperture())));
@@ -54,7 +54,7 @@ DgSqrD8Grid2DS::DgSqrD8Grid2DS (DgRFNetwork& networkIn,
    }
 
    // do the grids
-   
+
    long double fac = 1;
 
    DgDVec2D trans;
@@ -86,11 +86,11 @@ DgSqrD8Grid2DS::DgSqrD8Grid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0, 
-                                    trans); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0,
+                                    trans);
 
       (*grids_)[i] = new DgSqrD8Grid2D(network(), *ccRF, newName);
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[i]), i);
 
       fac *= radix();
@@ -99,7 +99,7 @@ DgSqrD8Grid2DS::DgSqrD8Grid2DS (DgRFNetwork& networkIn,
 } // DgSqrD8Grid2DS::DgSqrD8Grid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgSqrD8Grid2DS::DgSqrD8Grid2DS (const DgSqrD8Grid2DS& rf) 
+DgSqrD8Grid2DS::DgSqrD8Grid2DS (const DgSqrD8Grid2DS& rf)
   : DgDiscRFS2D (rf)
 {
    report("DgSqrD8Grid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -110,7 +110,7 @@ DgSqrD8Grid2DS::DgSqrD8Grid2DS (const DgSqrD8Grid2DS& rf)
 DgSqrD8Grid2DS::~DgSqrD8Grid2DS (void)
 {
    for (unsigned long i = 0; i < grids().size(); i++)
-    delete (*grids_)[i]; 
+    delete (*grids_)[i];
 
    delete grids_;
 } // DgSqrD8Grid2DS::~DgSqrD8Grid2DS
@@ -126,8 +126,8 @@ DgSqrD8Grid2DS::operator= (const DgSqrD8Grid2DS& rf)
 } // DgSqrD8Grid2DS& DgSqrD8Grid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                                DgLocVector& vec) const
 {
 //cout << "   setAddParents: " << add << endl;
@@ -160,10 +160,10 @@ DgSqrD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
       {
          bool found = false;
 
-         for (int j = 0; j < vec.size(); j++) 
+         for (int j = 0; j < vec.size(); j++)
          {
 //cout << "  " << i << " " << j << " " << (*verts)[i] << " " << vec[j];
-            if ((*verts)[i] == vec[j]) 
+            if ((*verts)[i] == vec[j])
             {
 //cout << " YES" << endl;
                found = true;
@@ -171,7 +171,7 @@ DgSqrD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
             }
 //cout << " NO" << endl;
          }
-         
+
          if (!found) vec.push_back((*verts)[i]);
       }
 //cout << "   parents: " << vec << endl;
@@ -182,8 +182,8 @@ DgSqrD8Grid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgSqrD8Grid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -196,7 +196,7 @@ DgSqrD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
          for (int j = 0; j < radix(); j++)
          {
             v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j), 
+             DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, lowerLeft.j() + j),
                                add.res() + 1)));
          }
       }
@@ -211,12 +211,12 @@ DgSqrD8Grid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
 
       delete tmpLoc;
    }
-   
+
 } // void DgSqrD8Grid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent() || radix() == 3)
@@ -236,8 +236,8 @@ DgSqrD8Grid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgSqrD8Grid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgSqrD8Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgSqrD8Grid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);

--- a/src/lib/dglib/lib/DgTriGrid2DS.cpp
+++ b/src/lib/dglib/lib/DgTriGrid2DS.cpp
@@ -31,13 +31,13 @@
 #include "DgTriGrid2DS.h"
 
 ////////////////////////////////////////////////////////////////////////////////
-DgTriGrid2DS::DgTriGrid2DS (DgRFNetwork& networkIn, 
-               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn, 
+DgTriGrid2DS::DgTriGrid2DS (DgRFNetwork& networkIn,
+               const DgRF<DgDVec2D, long double>& backFrameIn, int nResIn,
                unsigned int apertureIn, bool isCongruentIn, bool isAlignedIn,
                const string& nameIn)
-        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn, 
-                       isCongruentIn, isAlignedIn, nameIn) 
-{ 
+        : DgDiscRFS2D (networkIn, backFrameIn, nResIn, apertureIn,
+                       isCongruentIn, isAlignedIn, nameIn)
+{
    if (!isCongruent())
    {
       report("DgTriGrid2DS::DgTriGrid2DS() only congruent triangle grid "
@@ -68,11 +68,11 @@ DgTriGrid2DS::DgTriGrid2DS (DgRFNetwork& networkIn,
 
       DgContCartRF* ccRF = new DgContCartRF(network(), newName + string("bf"));
 
-      new Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0, 
-                                    trans); 
+      Dg2WayContAffineConverter(backFrame(), *ccRF, (long double) fac, 0.0,
+                                    trans);
 
       (*grids_)[i] = new DgTriGrid2D(network(), *ccRF, newName);
-      new Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
+      Dg2WayResAddConverter<DgIVec2D, DgDVec2D, long double>
                                                   (*this, *(grids()[i]), i);
 
       fac *= radix();
@@ -81,7 +81,7 @@ DgTriGrid2DS::DgTriGrid2DS (DgRFNetwork& networkIn,
 } // DgTriGrid2DS::DgTriGrid2DS
 
 ////////////////////////////////////////////////////////////////////////////////
-DgTriGrid2DS::DgTriGrid2DS (const DgTriGrid2DS& rf) 
+DgTriGrid2DS::DgTriGrid2DS (const DgTriGrid2DS& rf)
   : DgDiscRFS2D (rf)
 {
    report("DgTriGrid2DS::operator=() not implemented yet", DgBase::Fatal);
@@ -91,8 +91,8 @@ DgTriGrid2DS::DgTriGrid2DS (const DgTriGrid2DS& rf)
 ////////////////////////////////////////////////////////////////////////////////
 DgTriGrid2DS::~DgTriGrid2DS (void)
 {
-   for (unsigned long i = 0; i < grids().size(); i++) 
-    delete (*grids_)[i]; 
+   for (unsigned long i = 0; i < grids().size(); i++)
+    delete (*grids_)[i];
 
    delete grids_;
 
@@ -109,8 +109,8 @@ DgTriGrid2DS::operator= (const DgTriGrid2DS& rf)
 } // DgTriGrid2DS& DgTriGrid2DS::operator=
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgTriGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add, 
+void
+DgTriGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
                                DgLocVector& vec) const
 {
 //cout << "   setAddParents: " << add << endl;
@@ -133,8 +133,8 @@ DgTriGrid2DS::setAddParents (const DgResAdd<DgIVec2D>& add,
 } // void DgTriGrid2DS::setAddParents
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgTriGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgTriGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent())
@@ -154,7 +154,7 @@ DgTriGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
             for (long long int j = 0; j <= maxJ; j++)
             {
                v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-                           DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i, 
+                           DgResAdd<DgIVec2D>(DgIVec2D(lowerLeft.i() + i,
                                 lowerLeft.j() + j), add.res() + 1)));
             }
             maxJ += 2;
@@ -171,7 +171,7 @@ DgTriGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
             for (long long int j = 0; j <= maxJ; j++)
             {
                v.push_back(new DgAddress< DgResAdd<DgIVec2D> >(
-                           DgResAdd<DgIVec2D>(DgIVec2D(upperRight.i() - i, 
+                           DgResAdd<DgIVec2D>(DgIVec2D(upperRight.i() - i,
                                 upperRight.j() - j), add.res() + 1)));
             }
             maxJ += 2;
@@ -184,12 +184,12 @@ DgTriGrid2DS::setAddInteriorChildren (const DgResAdd<DgIVec2D>& add,
              "systems implemented", DgBase::Fatal);
    }
 //cout << vec << endl;
-   
+
 } // void DgTriGrid2DS::setAddInteriorChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgTriGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgTriGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
                                         DgLocVector& vec) const
 {
    if (isCongruent())
@@ -205,8 +205,8 @@ DgTriGrid2DS::setAddBoundaryChildren (const DgResAdd<DgIVec2D>& add,
 } // void DgTriGrid2DS::setAddBoundaryChildren
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
-DgTriGrid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add, 
+void
+DgTriGrid2DS::setAddAllChildren (const DgResAdd<DgIVec2D>& add,
                                    DgLocVector& vec) const
 {
    setAddInteriorChildren(add, vec);


### PR DESCRIPTION
This fixes a number of memory leaks caused by creating objects with new, but not freeing them afterwards. The solution is to simply create the objects. The pattern this introduces: creating objects but not saving them in a variable for use doesn't seem like a good design. Object constructors shouldn't have side-effects beyond creating the object, yet that must be what's happening here unless all the modified lines are unnecessary.

The code compiles and seems to run fine on my `cmake` branch; I've back-ported it here since that PR is still outstanding.