### PR TITLE
Fix shapelib include

### DIFF
--- a/src/lib/shapelib/CMakeLists.txt
+++ b/src/lib/shapelib/CMakeLists.txt
@@ -10,3 +10,4 @@ add_library(shapelib
 )
 
 target_include_directories(shapelib PUBLIC include)
+target_include_directories(shapelib PUBLIC include/shapelib)


### PR DESCRIPTION
Your move away from modules broke shapelib includes on my end. Adding this line makes them work the way I think you them to (`#include "shapelib.h"` in dglib code).