### PR TITLE
Fix an include path

### DIFF
--- a/src/lib/dglib/include/dglib/DgInShapefile.h
+++ b/src/lib/dglib/include/dglib/DgInShapefile.h
@@ -25,7 +25,7 @@
 #ifndef DGINSHAPEFILE_H
 #define DGINSHAPEFILE_H
 
-#include "dglib/DgInLocFile.h"
+#include <dglib/DgInLocFile.h>
 
 #include "shapefil.h"
 


### PR DESCRIPTION
Fixes an include path to use the `<>` notation.