### PR TITLE
Make DgLocation constructor non-private

### DIFF
--- a/src/lib/dglib/include/dglib/DgLocation.h
+++ b/src/lib/dglib/include/dglib/DgLocation.h
@@ -89,13 +89,13 @@ class DgLocation : public DgLocBase {
 
       virtual void clearAddress (void) { delete address_; address_ = 0; }
 
-   protected:
-
-      virtual void convertTo (const DgRFBase& rf) { rf.convert(this); }
-
       DgLocation (const DgRFBase& rfIn, DgAddressBase* addIn)
          : DgLocBase (rfIn),
            address_ (addIn) {}
+
+   protected:
+
+      virtual void convertTo (const DgRFBase& rf) { rf.convert(this); }
 
    protected:
 


### PR DESCRIPTION
In [this section](https://github.com/r-barnes/dggridR/blob/update_from_upstream/src/dglib.cpp#L149-L176) of dggridR the DgLocation constructor is used directly. Therefore, I either need it public in DGGRID or another way of achieving the same effect. Perhaps you have thoughts about a better way to structure this?

I find the logic in `transform.cpp` a little hard to follow (seqnum seems to be a special case?) - but could try adopting that. It's just a potentially longer path to getting things working again.