### PR TITLE
modify find_package(GDAL) calls to allow user to toggle on/off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,11 @@ else()
   add_compile_options(-Wall -pedantic)
 endif()
 
+option(WITH_GDAL "Build with external GDAL" ON)
 
+if(WITH_GDAL)
+    find_package(GDAL)
+endif()
 
 add_subdirectory(src/lib/dglib)
 add_subdirectory(src/lib/proj4lib)

--- a/src/apps/dggrid/CMakeLists.txt
+++ b/src/apps/dggrid/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
 
-find_package(GDAL)
-
 add_executable(dggrid
   binpres.cpp
   binvals.cpp

--- a/src/lib/dglib/CMakeLists.txt
+++ b/src/lib/dglib/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required (VERSION 3.9)
 
-find_package(GDAL)
-
 add_library(dglib
   lib/DgAddressBase.cpp
   lib/DgApSeq.cpp


### PR DESCRIPTION
Hello,
This PR tries to address #28 by adding a top level option `WITH_GDAL` cmake option. This option is `ON` by default, but a user can pass `cmake -DWITH_GDAL=OFF` when compiling to prevent searching for `GDAL` and just compiling as-is. I left the rest of the linking logic alone.

I also moved the `find_package(GDAL)` call up to the top level `CMakeLists.txt` which gets rid of some duplicated calls.

Compiles locally on `linux` with `gcc 9.4.0`.