### PR TITLE
Fix warning in DgEllipsoidRF copy constructor

### DIFF
--- a/src/lib/dglib/include/dglib/DgEllipsoidRF.h
+++ b/src/lib/dglib/include/dglib/DgEllipsoidRF.h
@@ -67,7 +67,7 @@ class DgGeoCoord : public DgDVec2D {
 
       DgGeoCoord (void) { }
 
-      DgGeoCoord (const DgGeoCoord& coord) { *this = coord; }
+      DgGeoCoord (const DgGeoCoord& coord) = default;
 
       DgGeoCoord (const DgDVec2D& coord, bool rads = true)
         { if (rads) *this = coord; else *this = coord * M_PI_180; }


### PR DESCRIPTION
Fixes:
```
/home/rick/projects/dggridR/src/src/DgEllipsoidRF.h:70:7: warning: base class ‘class DgDVec2D’ should be explicitly initialized in the copy constructor [-Wextra]
   70 |       DgGeoCoord (const DgGeoCoord& coord) { *this = coord; }
      |       ^~~~~~~~~~
```