### PR TITLE
Fix fallthru in DgOutShapefile

### DIFF
--- a/src/lib/dglib/lib/DgOutShapefile.cpp
+++ b/src/lib/dglib/lib/DgOutShapefile.cpp
@@ -36,11 +36,11 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-DgOutShapefile::DgOutShapefile (const DgGeoSphDegRF& rfIn, 
-            const string& fileNameIn, int precisionIn, bool isPointFileIn, 
+DgOutShapefile::DgOutShapefile (const DgGeoSphDegRF& rfIn,
+            const string& fileNameIn, int precisionIn, bool isPointFileIn,
             int shapefileIdLen, DgReportLevel failLevelIn)
    : DgOutLocFile (fileNameIn, rfIn, isPointFileIn, failLevelIn),
-     geoRF_ (rfIn.geoRF()), dbFile_ (NULL), shpFile_ (NULL), recNum_ (0), 
+     geoRF_ (rfIn.geoRF()), dbFile_ (NULL), shpFile_ (NULL), recNum_ (0),
      numDigits_ (precisionIn), numFields_ (0), idLen_ (shapefileIdLen)
 {
    // test for override of vecAddress
@@ -57,7 +57,7 @@ DgOutShapefile::DgOutShapefile (const DgGeoSphDegRF& rfIn,
 } // DgOutShapefile::DgOutShapefile
 
 ////////////////////////////////////////////////////////////////////////////////
-bool 
+bool
 DgOutShapefile::open (const string& fileName, DgReportLevel failLevel)
 {
    // create the database file
@@ -84,7 +84,7 @@ DgOutShapefile::open (const string& fileName, DgReportLevel failLevel)
    DBFClose(dbFile_);
 
    dbFile_ = DBFOpen(dbFileName_.c_str(), "rb+");
-   if (!dbFile_) 
+   if (!dbFile_)
       report("DgOutShapefile::open() unable to open database file " +
              dbFileName_, failLevel);
 
@@ -98,7 +98,7 @@ DgOutShapefile::open (const string& fileName, DgReportLevel failLevel)
    else
       shpFile_ = SHPCreate(shpFileName_.c_str(), SHPT_POLYGON);
 
-   if (!shpFile_) 
+   if (!shpFile_)
       report("DgOutShapefile::open() unable to create shapefile " +
              shpFileName_, failLevel);
 
@@ -148,7 +148,7 @@ DgOutShapefile::open (const string& fileName, DgReportLevel failLevel)
 } // DgOutShapefile::open
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
+void
 DgOutShapefile::addFields (const set<DgDBFfield>& fields)
 {
    if (DBFGetRecordCount(dbFile_) > 0)
@@ -157,10 +157,10 @@ DgOutShapefile::addFields (const set<DgDBFfield>& fields)
 
 //cout << "Adding fields: " << endl;
 
-   for (set<DgDBFfield>::iterator it = fields.begin(); 
+   for (set<DgDBFfield>::iterator it = fields.begin();
            it != fields.end(); it++)
    {
-      if (DBFAddField(dbFile_, it->fieldName().c_str(), it->type(), 
+      if (DBFAddField(dbFile_, it->fieldName().c_str(), it->type(),
              it->width(), it->precision()) == -1)
          ::report("DgOutShapefile::addFields() unable to add " + it->fieldName()
                 + " in file " + dbFileName_, DgBase::Fatal);
@@ -172,7 +172,7 @@ DgOutShapefile::addFields (const set<DgDBFfield>& fields)
    DBFClose(dbFile_);
 
    dbFile_ = DBFOpen(dbFileName_.c_str(), "rb+");
-   if (!dbFile_) 
+   if (!dbFile_)
       report("DgOutShapefile::addFields() unable to reopen database file " +
              dbFileName_, DgBase::Fatal);
 
@@ -196,7 +196,7 @@ DgOutShapefile::insert (const DgDVec2D& pt)
 } // DgOutLocFile& DgOutShapefile::insert
 
 ////////////////////////////////////////////////////////////////////////////////
-void 
+void
 DgOutShapefile::writeDbf (const string& id)
 {
    // write the label
@@ -204,7 +204,7 @@ DgOutShapefile::writeDbf (const string& id)
       ::report("DgOutShapefile::writeDbf() index string length of " +
                dgg::util::to_string(id.length()) + " exceeds value "
                "of parameter shapefile_id_field_length.", failLevel());
-   
+
    if (!DBFWriteStringAttribute(dbFile_, recNum_, 0, id.c_str()))
       report("DgOutShapefile::writeDbf() unable to write to " +
              dbFileName_, failLevel());
@@ -219,7 +219,7 @@ DgOutShapefile::writeDbf (const string& id)
                 dbFileName_, failLevel());
 
       // now write default values to the fields that are present
-      for (set<DgDBFfield>::iterator it = curFields_.begin(); 
+      for (set<DgDBFfield>::iterator it = curFields_.begin();
            it != curFields_.end(); it++)
       {
          int fNum = DBFGetFieldIndex(dbFile_, it->fieldName().c_str());
@@ -242,8 +242,7 @@ DgOutShapefile::writeDbf (const string& id)
             case FTLogical:
                ::report("DgOutShapefile::writeDbf() logical shapefile "
                    "attributes not supported", failLevel());
-            default:
-               res = false;
+               break;
          }
 
          if (!res)
@@ -278,7 +277,7 @@ DgOutShapefile::insert (DgLocation& loc, const string* label)
    // now write to the files
    writeDbf(id.c_str());
 
-   SHPObject *ptShape = SHPCreateObject(SHPT_POINT, recNum_, 0, NULL, NULL, 1, 
+   SHPObject *ptShape = SHPCreateObject(SHPT_POINT, recNum_, 0, NULL, NULL, 1,
                              &x, &y, NULL, NULL);
    SHPWriteObject(shpFile_, -1, ptShape);
    SHPDestroyObject(ptShape);
@@ -292,7 +291,7 @@ DgOutShapefile::insert (DgLocation& loc, const string* label)
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 DgOutLocFile&
-DgOutShapefile::insert (DgLocVector& vec, const string* label, 
+DgOutShapefile::insert (DgLocVector& vec, const string* label,
                      const DgLocation* cent)
 //
 // Put the polyline vec.
@@ -309,7 +308,7 @@ DgOutShapefile::insert (DgLocVector& vec, const string* label,
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 DgOutLocFile&
-DgOutShapefile::insert (DgPolygon& poly, const string* label, 
+DgOutShapefile::insert (DgPolygon& poly, const string* label,
                      const DgLocation* cent)
 //
 // Put the polygon poly.
@@ -332,7 +331,7 @@ DgOutShapefile::insert (DgPolygon& poly, const string* label,
 
    // need to reverse order to get clockwise winding
    int oldNdx = (int) v.size() - 1;
-   for (int newNdx = 0; newNdx < numVerts - 1; newNdx++) 
+   for (int newNdx = 0; newNdx < numVerts - 1; newNdx++)
    {
       DgDVec2D vec = rf().getVecAddress(*v[oldNdx]);
       x[newNdx] = vec.x();
@@ -340,7 +339,7 @@ DgOutShapefile::insert (DgPolygon& poly, const string* label,
 
       oldNdx--;
    }
-   
+
    // complete the ring by repeating the first vertex
    x[numVerts - 1] = x[0];
    y[numVerts - 1] = y[0];


### PR DESCRIPTION
Fixes:
```
/home/rick/projects/dggridR/src/src/DgOutShapefile.cpp: In member function ‘void DgOutShapefile::writeDbf(const string&)’:
/home/rick/projects/dggridR/src/src/DgOutShapefile.cpp:243:24: warning: this statement may fall through [-Wimplicit-fallthrough=]
  243 |                ::report("DgOutShapefile::writeDbf() logical shapefile "
      |                ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  244 |                    "attributes not supported", failLevel());
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I think `failLevel()` causes the code to quit here. Adding a break eliminates the warning.