### PR TITLE
Fix REprintf in safileio.c

### DIFF
--- a/src/lib/shapelib/lib/safileio.c
+++ b/src/lib/shapelib/lib/safileio.c
@@ -13,7 +13,7 @@
  * option is discussed in more detail in shapelib.html.
  *
  * --
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -51,8 +51,8 @@
  *
  * Revision 1.2  2007/12/15 20:25:30  bram
  * dbfopen.c now reads the Code Page information from the DBF file, and exports
- * this information as a string through the DBFGetCodePage function.  This is 
- * either the number from the LDID header field ("LDID/<number>") or as the 
+ * this information as a string through the DBFGetCodePage function.  This is
+ * either the number from the LDID header field ("LDID/<number>") or as the
  * content of an accompanying .CPG file.  When creating a DBF file, the code can
  * be set using DBFCreateEx.
  *
@@ -98,7 +98,7 @@ SAFile SADFOpen( const char *pszFilename, const char *pszAccess )
 SAOffset SADFRead( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 
 {
-    return (SAOffset) fread( p, (size_t) size, (size_t) nmemb, 
+    return (SAOffset) fread( p, (size_t) size, (size_t) nmemb,
                              (FILE *) file );
 }
 
@@ -109,7 +109,7 @@ SAOffset SADFRead( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 SAOffset SADFWrite( void *p, SAOffset size, SAOffset nmemb, SAFile file )
 
 {
-    return (SAOffset) fwrite( p, (size_t) size, (size_t) nmemb, 
+    return (SAOffset) fwrite( p, (size_t) size, (size_t) nmemb,
                               (FILE *) file );
 }
 
@@ -171,7 +171,7 @@ void SADError( const char *message )
 
 {
 #ifdef DGGRIDR
-    REprintf( stderr, "%s\n", message );
+    REprintf( "%s\n", message );
 #else
     fprintf( stderr, "%s\n", message );
 #endif
@@ -210,7 +210,7 @@ const wchar_t* Utf8ToWideChar( const char *pszFilename )
 {
     int nMulti, nWide;
     wchar_t *pwszFileName;
-    
+
     nMulti = strlen(pszFilename) + 1;
     nWide = MultiByteToWideChar( CP_UTF8, 0, pszFilename, nMulti, 0, 0);
     if( nWide == 0 )
@@ -256,7 +256,7 @@ SAFile SAUtf8WFOpen( const char *pszFilename, const char *pszAccess )
 int SAUtf8WRemove( const char *pszFilename )
 {
     const wchar_t *pwszFileName = Utf8ToWideChar( pszFilename );
-    int rc = -1; 
+    int rc = -1;
     if( pwszFileName != NULL )
     {
         rc = _wremove( pwszFileName );
@@ -275,7 +275,7 @@ int SAUtf8WRemove( const char *pszFilename )
 
 void SASetupUtf8Hooks( SAHooks *psHooks )
 {
-#ifdef SHPAPI_WINDOWS    
+#ifdef SHPAPI_WINDOWS
     psHooks->FOpen   = SAUtf8WFOpen;
     psHooks->Remove  = SAUtf8WRemove;
 #else


### PR DESCRIPTION
Fixes an `REprintf` call by changing it to
```
REprintf( "%s\n", message );
```
the other changes are trimmed whitespace. It's likely your code editor can be figured to trim these automatically, which would make merging easier.