### PR TITLE
Use memcpy instead of strncpy

### DIFF
--- a/src/lib/shapelib/lib/dbfopen.c
+++ b/src/lib/shapelib/lib/dbfopen.c
@@ -1476,7 +1476,7 @@ static int DBFWriteAttribute(DBFHandle psDBF, int hEntity, int iField,
             szSField[psDBF->panFieldSize[iField]] = '\0';
             nRetResult = FALSE;
         }
-        strncpy((char *) (pabyRec+psDBF->panFieldOffset[iField]),
+        memcpy((char *) (pabyRec+psDBF->panFieldOffset[iField]),
             szSField, strlen(szSField) );
         break;
       }

--- a/src/lib/shapelib/lib/shputils.c
+++ b/src/lib/shapelib/lib/shputils.c
@@ -397,8 +397,8 @@ void showitems()
             for( iRecord = 0; iRecord < maxrec; iRecord++ ) {
                 strncpy(stmp,DBFReadStringAttribute( hDBF, iRecord, i ),39);
                 if (strcmp(stmp,"!!") > 0) {
-                    if (strncasecmp2(stmp,slow,0)  < 0) strncpy(slow, stmp,39);
-                    if (strncasecmp2(stmp,shigh,0) > 0) strncpy(shigh,stmp,39);
+                    if (strncasecmp2(stmp,slow,0)  < 0) memcpy(slow, stmp,39);
+                    if (strncasecmp2(stmp,shigh,0) > 0) memcpy(shigh,stmp,39);
                 }
             }
             pt=slow+strlen(slow)-1; 


### PR DESCRIPTION
This follows the upstream code:
* https://github.com/OSGeo/shapelib/blob/master/dbfopen.c#L1310
* https://github.com/OSGeo/shapelib/blob/master/shputils.c#L342-L343

and fixes warnings from R's win-builder:
```
  dbfopen.c:1482:9: warning: 'strncpy' output may be truncated copying between 0 and 255 bytes from a string of length 255 [-Wstringop-truncation]
  shputils.c:403:57: warning: 'strncpy' output may be truncated copying 39 bytes from a string of length 39 [-Wstringop-truncation]
  shputils.c:404:57: warning: 'strncpy' output may be truncated copying 39 bytes from a string of length 39 [-Wstringop-truncation]
```