### PR TITLE
Remove unary::function inheritance

### DIFF
--- a/src/lib/dglib/include/dglib/DgColor.h
+++ b/src/lib/dglib/include/dglib/DgColor.h
@@ -133,7 +133,7 @@ inline ostream& operator<< (ostream& stream, const DgColor& color)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class DgColorEq : public unary_function<DgColor*, bool> {
+class DgColorEq {
 
    public:
 


### PR DESCRIPTION
`std::unary_function` is deprecated ([link](https://stackoverflow.com/a/63577511/752843)) and this is causing a warning in R's win-builder:
```
  DgColor.h:139:26: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
```
The code compiles without `std::unary_function`, so let's eliminate it.