### PR TITLE
For conda-forge package make shapelib linkable as dynamic package

### DIFF
--- a/.github/workflows/earthly_ci_build.yml
+++ b/.github/workflows/earthly_ci_build.yml
@@ -1,0 +1,21 @@
+name: GitHub Actions CI
+
+on:
+  push:
+    branches: [master,deva]
+  pull_request:
+    branches: [master]
+
+jobs:
+  tests:
+    name: example earthly test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: "latest"
+      - uses: actions/checkout@v2
+      - name: what version is installed?
+        run: earthly --version
+      - name: run the earthly hello world
+        run: earthly +test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,20 +9,30 @@ find_package(Doxygen)
 
 #Adds aggressive warnings to all compilation
 if(MSVC)
-  add_compile_options(/W4 /WX)
+  # add_compile_options(/W4 /WX)
+  add_compile_options(/W2)
 else()
   add_compile_options(-Wall -pedantic)
 endif()
 
+
 option(WITH_GDAL "Build with external GDAL" ON)
+option(WITH_EXT_SHAPELIB "Build with external SHAPELIB" OFF)
 
 if(WITH_GDAL)
     find_package(GDAL)
 endif()
 
+if(WITH_EXT_SHAPELIB)
+  list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/src/lib/shapelib_ext)
+  find_package(shapelib REQUIRED)
+else()
+  add_subdirectory(src/lib/shapelib)
+endif()
+
 add_subdirectory(src/lib/dglib)
 add_subdirectory(src/lib/proj4lib)
-add_subdirectory(src/lib/shapelib)
+# add_subdirectory(src/lib/shapelib)
 
 add_subdirectory(src/apps/dggrid)
 add_subdirectory(src/apps/appex)

--- a/Earthfile
+++ b/Earthfile
@@ -24,6 +24,37 @@ build:
   RUN --mount=type=cache,target=/code/build/CMakeFiles cd build && make
   SAVE ARTIFACT build/src/apps/dggrid/dggrid AS LOCAL dggrid
 
+test:
+  FROM +build
+  COPY +build/dggrid /bin/dggrid
+  COPY examples examples
+  RUN cd /code/examples/aigenerate && /bin/dggrid aigenerate.meta > outputfiles/aigenerate.txt
+  RUN cd /code/examples/binpres && /bin/dggrid binpres.meta > outputfiles/binpres.txt
+  RUN cd /code/examples/binvals && /bin/dggrid binvals.meta > outputfiles/binvals.txt
+  RUN cd /code/examples/determineRes && /bin/dggrid determineRes.meta > outputfiles/determineRes.txt
+  RUN cd /code/examples/gdalCollection && /bin/dggrid gdalCollection.meta > outputfiles/gdalCollection.txt
+  RUN cd /code/examples/gdalExample && /bin/dggrid gdalExample.meta > outputfiles/gdalExample.txt
+  RUN cd /code/examples/gridgenCellClip && /bin/dggrid gridgenCellClip.meta > outputfiles/gridgenCellClip.txt
+  RUN cd /code/examples/gridgenDiamond && /bin/dggrid gridgenDiamond.meta > outputfiles/gridgenDiamond.txt
+  RUN cd /code/examples/gridgenGeoJSON && /bin/dggrid gridgenGeoJSON.meta > outputfiles/gridgenGeoJSON.txt
+  RUN cd /code/examples/gridgenMixedSHP && /bin/dggrid gridgenMixedSHP.meta > outputfiles/gridgenMixedSHP.txt
+  RUN cd /code/examples/gridgenPureKML && /bin/dggrid gridgenPureKML.meta > outputfiles/gridgenPureKML.txt
+  RUN cd /code/examples/hiRes && /bin/dggrid hiRes.meta > outputfiles/hiRes.txt
+  RUN cd /code/examples/holes && /bin/dggrid holes.meta > outputfiles/holes.txt
+  RUN cd /code/examples/icosahedron && /bin/dggrid icosahedron.meta > outputfiles/icosahedron.txt
+  RUN cd /code/examples/isea7hGen && /bin/dggrid isea7hGen.meta > outputfiles/isea7hGen.txt
+  RUN cd /code/examples/mixedAperture && /bin/dggrid mixedAperture.meta > outputfiles/mixedAperture.txt
+  RUN cd /code/examples/planetRiskGridGen && /bin/dggrid planetRiskGridGen.meta > outputfiles/planetRiskGridGen.txt
+  RUN cd /code/examples/planetRiskGridNoWrap && /bin/dggrid planetRiskGridNoWrap.meta > outputfiles/planetRiskGridNoWrap.txt
+  RUN cd /code/examples/planetRiskClipHiRes && /bin/dggrid planetRiskClipHiRes.meta > outputfiles/planetRiskClipHiRes.txt
+  RUN cd /code/examples/planetRiskClipMulti && /bin/dggrid planetRiskClipMulti.meta > outputfiles/planetRiskClipMulti.txt
+  RUN cd /code/examples/planetRiskTable && /bin/dggrid planetRiskTable.meta > outputfiles/planetRiskTable.txt
+  RUN cd /code/examples/seqnums && /bin/dggrid seqnums.meta > outputfiles/seqnums.txt
+  RUN cd /code/examples/superfundGrid && /bin/dggrid superfundGrid.meta > outputfiles/superfundGrid.txt
+  RUN cd /code/examples/table && /bin/dggrid table.meta > outputfiles/table.txt
+  RUN cd /code/examples/transform && /bin/dggrid transform.meta > outputfiles/transform.txt
+
+
 docker:
   COPY +build/dggrid /bin/dggrid
   ENTRYPOINT ["/bin/dggrid"]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,8 @@ and include them appropriately.
 
 By default cmake will search for `GDAL` and link __DGGRID__ with it if found. If `GDAL` is present on your system and you want to force a build of __DGGRID__ without `GDAL`, call cmake with `-DWITH_GDAL=OFF`.
 
+By default cmake will use an included vendored version of SHAPELIB. You can build also build and link against a system-provided version of shapelib. You can activate it by calling cmake with `-DWITH_EXT_SHAPELIB=ON`, and cmake search for `shapelib` and link __DGGRID__ with it if found. In addition you can provide `-DSHAPELIB_ROOT_DIR=/usr/..` as the search path.
+
 You can also build DGGRID with extra debugging info. Doing this requires
 emptying your `build/` directory first or making a new `build_debug/` directory.
 

--- a/src/lib/proj4lib/LICENSE
+++ b/src/lib/proj4lib/LICENSE
@@ -1,0 +1,10 @@
+ The MIT License (MIT)
+
+Copyright © 2013 Gerald Evenden Kevin Sahr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/src/lib/shapelib/LICENSE
+++ b/src/lib/shapelib/LICENSE
@@ -1,0 +1,11 @@
+ The MIT License (MIT)
+
+* Copyright (c) 1999, Frank Warmerdam
+* Copyright (c) 2012-2016, Even Rouault <even dot rouault at mines-paris dot org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/src/lib/shapelib_ext/Findshapelib.cmake
+++ b/src/lib/shapelib_ext/Findshapelib.cmake
@@ -1,0 +1,66 @@
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# FindSHAPELIB
+# ------
+#
+# Find SHAPELIB (shapelib) include directories and libraries.
+#
+# This module will set the following variables:
+#
+#  SHAPELIB_FOUND          - System has SHAPELIB
+#  SHAPELIB_INCLUDE_DIRS   - The SHAPELIB include directories
+#  SHAPELIB_LIBRARIES      - The libraries needed to use SHAPELIB
+#
+# This module will also create the "tbb" target that may be used when building
+# executables and libraries.
+
+include(FindPackageHandleStandardArgs)
+
+find_path(shapelib_INCLUDE_DIR shapefil.h
+  HINTS
+    ENV SHAPELIB_ROOT
+    ENV SHAPELIB_DIR
+    ${SHAPELIB_ROOT_DIR}
+  PATH_SUFFIXES
+    include
+  )
+
+find_library(shapelib_LIBRARY
+  NAMES
+    libshp
+    shp
+  HINTS
+    ENV SHAPELIB_ROOT
+    ENV SHAPELIB_DIR
+    ${SHAPELIB_ROOT_DIR}
+  PATH_SUFFIXES
+    lib
+    libs
+    Library
+  )
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(shapelib
+  REQUIRED_VARS shapelib_INCLUDE_DIR shapelib_LIBRARY
+  )
+
+if(SHAPELIB_FOUND)
+  set(shapelib_INCLUDE_DIRS ${shapelib_INCLUDE_DIR})
+  set(shapelib_LIBRARIES ${shapelib_LIBRARY})
+
+  add_library(shapelib SHARED IMPORTED)
+  set_target_properties(shapelib PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${shapelib_INCLUDE_DIRS}
+    IMPORTED_LOCATION ${shapelib_LIBRARIES}
+    IMPORTED_IMPLIB ${shapelib_LIBRARIES}
+    )
+
+  mark_as_advanced(shapelib_INCLUDE_DIRS shapelib_LIBRARIES)
+endif()


### PR DESCRIPTION
I added minimal CMAKE config changes, that when running cmake obliviously" shouldn't have any impact. By setting a switch `WITH_EXT_SHAPELIB` cmake should source an additional config file and try to find the system-provided one.

By default cmake will use the included vendored version of SHAPELIB. One can now also build also build and link DGGRID against a system-provided version of shapelib (e.g. from conda-forge or manually installed). It can be activated it by calling cmake with `-DWITH_EXT_SHAPELIB=ON`, and cmake search for `shapelib` and link __DGGRID__ with it if found. In addition, one can provide `-DSHAPELIB_ROOT_DIR=/..` as a search path.

The original intention is to package DGGRID with [conda](https://github.com/conda-forge/staged-recipes/pull/21947).