### PR TITLE
Fixing  #62

### DIFF
--- a/src/lib/dglib/lib/DgDmdIDGG.cpp
+++ b/src/lib/dglib/lib/DgDmdIDGG.cpp
@@ -120,7 +120,7 @@ DgDmdIDGG::initialize (void)
       double factor = parentScaleFac * 2.0L; // aperture 4
 
       scaleFac_ = factor;
-      maxD_ = factor - 1.0L;
+      maxD_ = factor+0.000001 - 1.0L;
 
       //cout << res() << " " << aperture();
       //cout << " f: " << factor << " maxD: " << maxD_ << endl;

--- a/src/lib/dglib/lib/DgHexIDGG.cpp
+++ b/src/lib/dglib/lib/DgHexIDGG.cpp
@@ -164,7 +164,7 @@ DgHexIDGG::initialize (void)
       if (isClassIII())
          factor *= M_SQRT7;
 
-      maxD_ = factor - 1.0;
+      maxD_ = factor+0.000001 - 1.0;
 
       //cout << res() << " " << aperture();
       //cout << " f: " << factor << " maxD: " << maxD_ << endl;

--- a/src/lib/dglib/lib/DgTriIDGG.cpp
+++ b/src/lib/dglib/lib/DgTriIDGG.cpp
@@ -114,7 +114,7 @@ DgTriIDGG::initialize (void)
       double factor = parentScaleFac * 2.0L; // aperture 4
 
       scaleFac_ = factor;
-      maxD_ = factor - 1.0L;
+      maxD_ = factor+0.000001 - 1.0L;
 
       //cout << res() << " " << aperture();
       //cout << " f: " << factor << " maxD: " << maxD_ << endl;


### PR DESCRIPTION
The issue on Apple silicon computers appears to be caused by this implicit conversion of double's to long integers, which is rounded downwards. Adding a small number here remedies this. I am of course not able to sort out all numeric precision issues with DGGRID (this alone took me 6 hours of simultaneous debugging on Mac and Windows to find out where the two start to differ). But the main issue of giving wrong seqnums for some coordinates seems to be solved by it. 