### PR TITLE
Make a direct converter for Z7 to/from Q2DI

### DIFF
--- a/src/lib/dglib/include/dglib/DgZ7StringRF.h
+++ b/src/lib/dglib/include/dglib/DgZ7StringRF.h
@@ -39,17 +39,17 @@ class DgZ7StringCoord;
 using namespace std;
 
 ////////////////////////////////////////////////////////////////////////////////
-class DgQ2DItoZ7StringConverter :
-        public DgConverter<DgQ2DICoord, long long int, DgZ7StringCoord, long long int>
+class DgQ2DItoZ7Converter :
+        public DgConverter<DgQ2DICoord, long long int, DgZ7Coord, long long int>
 {
    public:
 
-      DgQ2DItoZ7StringConverter (const DgRF<DgQ2DICoord, long long int>& from,
-                                   const DgRF<DgZ7StringCoord, long long int>& to);
+      DgQ2DItoZ7Converter (const DgRF<DgQ2DICoord, long long int>& from,
+                                   const DgRF<DgZ7Coord, long long int>& to);
 
       const DgIDGGBase& IDGG (void) const { return *pIDGG_; }
 
-      virtual DgZ7StringCoord convertTypedAddress
+      virtual DgZ7Coord convertTypedAddress
                                 (const DgQ2DICoord& addIn) const;
 
    protected:
@@ -61,18 +61,18 @@ class DgQ2DItoZ7StringConverter :
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-class DgZ7StringToQ2DIConverter :
-        public DgConverter<DgZ7StringCoord, long long int, DgQ2DICoord, long long int>
+class DgZ7ToQ2DIConverter :
+        public DgConverter<DgZ7Coord, long long int, DgQ2DICoord, long long int>
 {
    public:
 
-      DgZ7StringToQ2DIConverter (const DgRF<DgZ7StringCoord, long long int>& from,
+      DgZ7ToQ2DIConverter (const DgRF<DgZ7Coord, long long int>& from,
                                    const DgRF<DgQ2DICoord, long long int>& to);
 
       const DgIDGGBase& IDGG (void) const { return *pIDGG_; }
 
       virtual DgQ2DICoord convertTypedAddress
-                                (const DgZ7StringCoord& addIn) const;
+                                (const DgZ7Coord& addIn) const;
 
    protected:
 
@@ -83,14 +83,14 @@ class DgZ7StringToQ2DIConverter :
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-class Dg2WayZ7StringConverter : public Dg2WayConverter {
+class Dg2WayZ7Converter : public Dg2WayConverter {
 
    public:
 
-      Dg2WayZ7StringConverter (const DgRF<DgQ2DICoord, long long int>& fromFrame,
-              const DgRF<DgZ7StringCoord, long long int>& toFrame)
-         : Dg2WayConverter (*(new DgQ2DItoZ7StringConverter(fromFrame, toFrame)),
-              *(new DgZ7StringToQ2DIConverter(toFrame, fromFrame))) {}
+      Dg2WayZ7Converter (const DgRF<DgQ2DICoord, long long int>& fromFrame,
+              const DgRF<DgZ7Coord, long long int>& toFrame)
+         : Dg2WayConverter (*(new DgQ2DItoZ7Converter(fromFrame, toFrame)),
+              *(new DgZ7ToQ2DIConverter(toFrame, fromFrame))) {}
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/lib/dglib/lib/DgIDGGBase.cpp
+++ b/src/lib/dglib/lib/DgIDGGBase.cpp
@@ -236,11 +236,11 @@ DgIDGGBase::createConverters (void)
 
     Dg2WayConverter* toZ7Str = NULL;
     Dg2WayConverter* toZ7 = NULL;
-    if (z7StrRF()) {
-       toZ7Str = new Dg2WayZ7StringConverter(*this, *z7StrRF());
+    if (z7RF()) {
+       toZ7 = new Dg2WayZ7Converter(*this, *z7RF());
 
-       if (z7RF())
-          toZ7 = new Dg2WayZ7ToStringConverter(*z7StrRF(), *z7RF());
+       if (z7StrRF())
+          toZ7Str = new Dg2WayZ7ToStringConverter(*z7StrRF(), *z7RF());
     }
 
     // suppress unused variable error

--- a/src/lib/dglib/lib/DgZ7StringRF.cpp
+++ b/src/lib/dglib/lib/DgZ7StringRF.cpp
@@ -27,6 +27,7 @@
 #include <cfloat>
 #include <string.h>
 
+#include <dglib/DgZ7RF.h>
 #include <dglib/DgZ7StringRF.h>
 #include <dglib/DgIDGGBase.h>
 #include <dglib/DgIDGGSBase.h>
@@ -61,31 +62,31 @@ DgZ7StringRF::str2add (DgZ7StringCoord* add, const char* str,
 } // const char* DgZ7StringRF::str2add
 
 ////////////////////////////////////////////////////////////////////////////////
-DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter
+DgQ2DItoZ7Converter::DgQ2DItoZ7Converter
                 (const DgRF<DgQ2DICoord, long long int>& from,
-                 const DgRF<DgZ7StringCoord, long long int>& to)
-        : DgConverter<DgQ2DICoord, long long int, DgZ7StringCoord, long long int> (from, to),
+                 const DgRF<DgZ7Coord, long long int>& to)
+        : DgConverter<DgQ2DICoord, long long int, DgZ7Coord, long long int> (from, to),
           pIDGG_ (NULL), effRes_ (0), effRadix_ (0)
 {
    pIDGG_ = dynamic_cast<const DgIDGGBase*>(&fromFrame());
    if (!pIDGG_) {
-      report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
+      report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
          " fromFrame not of type DgIDGGBase", DgBase::Fatal);
    }
 
-   const DgZ7StringRF* zRF = dynamic_cast<const DgZ7StringRF*>(&toFrame());
+   const DgZ7RF* zRF = dynamic_cast<const DgZ7RF*>(&toFrame());
    if (!zRF) {
-      report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
-         " toFrame not of type DgZ7StringRF", DgBase::Fatal);
+      report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
+         " toFrame not of type DgZ7RF", DgBase::Fatal);
    }
 
    if (IDGG().dggs()->aperture() != zRF->aperture() || IDGG().res() != zRF->res()) {
-       report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
+       report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
          "fromFrame and toFrame apertures or resolutions do not match", DgBase::Fatal);
    }
 
    if (IDGG().gridTopo() != Hexagon || IDGG().dggs()->aperture() != 7) {
-      report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
+      report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
          "only implemented for aperture 7 hexagon grids", DgBase::Fatal);
    }
 
@@ -94,13 +95,13 @@ DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter
    // effRes_ is the number of Class I resolutions
    effRes_ = (IDGG().res() + 1) / 2;
 
-} // DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter
+} // DgQ2DItoZ7Converter::DgQ2DItoZ7Converter
 
 ////////////////////////////////////////////////////////////////////////////////
-DgZ7StringCoord
-DgQ2DItoZ7StringConverter::convertTypedAddress (const DgQ2DICoord& addIn) const
+DgZ7Coord
+DgQ2DItoZ7Converter::convertTypedAddress (const DgQ2DICoord& addIn) const
 {
-   //printf("DgQ2DItoZ7StringConverter::convertTypedAddress\n");
+   //printf("DgQ2DItoZ7Converter::convertTypedAddress\n");
 /*
    // check for res 0/base cell
     if (res == 0) {
@@ -223,8 +224,7 @@ DgQ2DItoZ7StringConverter::convertTypedAddress (const DgQ2DICoord& addIn) const
 
    // dgcout << " "; // KEVIN
 
-    string bcstr = dgg::util::to_string(baseCell, 2);
-    string addstr = bcstr;
+    uint64_t z7index = (uint64_t)baseCell << 60; // shift to top bits
     DgIVec3D::Direction skipDigit = ((baseCell < 6) ? DgIVec3D::PENTAGON_SKIPPED_DIGIT_TYPE1 : DgIVec3D::PENTAGON_SKIPPED_DIGIT_TYPE2);
     int skipRotate = false;
     int firstNonZero = false;
@@ -239,49 +239,52 @@ DgQ2DItoZ7StringConverter::convertTypedAddress (const DgQ2DICoord& addIn) const
         if (skipRotate) {
             d = DgIVec3D::rotate60ccw(d);
         }
-
-        addstr = addstr + to_string((int) d);
+        auto shift = 3 * (20 - r);
+        z7index |= (uint64_t)d << shift;
     }
+
+    for (int r = res + 1; r <= 20; r++)
+        z7index |= (uint64_t)0x7 << (3 * (20 - r));
 
     free(digits);
     digits = NULL;
 
-    DgZ7StringCoord z7str;
-    z7str.setValString(addstr);
+    DgZ7Coord z7;
+    z7.setValue(z7index);
 //dgcout << z7str << endl; // KEVIN
     //dgcout << "KEVIN addIn: " << addIn << " baseijk: " << baseCellIjk << " z7str: " << z7str << endl;
     //dgcout << z7str << " " << addIn << endl;
 
-    return z7str;
+    return z7;
 
-} // DgZ7StringCoord DgQ2DItoZ7StringConverter::convertTypedAddress
+} // DgZ7StringCoord DgQ2DItoZ7Converter::convertTypedAddress
 
 ////////////////////////////////////////////////////////////////////////////////
-DgZ7StringToQ2DIConverter::DgZ7StringToQ2DIConverter
-                (const DgRF<DgZ7StringCoord, long long int>& from,
+DgZ7ToQ2DIConverter::DgZ7ToQ2DIConverter
+                (const DgRF<DgZ7Coord, long long int>& from,
                  const DgRF<DgQ2DICoord, long long int>& to)
-        : DgConverter<DgZ7StringCoord, long long int, DgQ2DICoord, long long int> (from, to),
+        : DgConverter<DgZ7Coord, long long int, DgQ2DICoord, long long int> (from, to),
           pIDGG_ (NULL), res_ (0), numClassI_ (0), unitScaleClassIres_ (0)
 {
    pIDGG_ = dynamic_cast<const DgIDGGBase*>(&toFrame());
    if (!pIDGG_) {
-      report("DgZ7StringToQ2DIConverter::DgZ7StringToQ2DIConverter(): "
+      report("DgZ7ToQ2DIConverter::DgZ7ToQ2DIConverter(): "
          " toFrame not of type DgIDGGBase", DgBase::Fatal);
    }
 
-   const DgZ7StringRF* zRF = dynamic_cast<const DgZ7StringRF*>(&fromFrame());
+   const DgZ7RF* zRF = dynamic_cast<const DgZ7RF*>(&fromFrame());
    if (!zRF) {
-      report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
-         " fromFrame not of type DgZ7StringRF", DgBase::Fatal);
+      report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
+         " fromFrame not of type DgZ7RF", DgBase::Fatal);
    }
 
    if (IDGG().dggs()->aperture() != zRF->aperture() || IDGG().res() != zRF->res()) {
-      report("DgQ2DItoZ7StringConverter::DgQ2DItoZ7StringConverter(): "
+      report("DgQ2DItoZ7Converter::DgQ2DItoZ7Converter(): "
          " fromFrame and toFrame apertures or resolutions do not match", DgBase::Fatal);
    }
 
    if (IDGG().gridTopo() != Hexagon || IDGG().dggs()->aperture() != 7) {
-      report("DgZ7StringToQ2DIConverter::DgZ7StringToQ2DIConverter(): "
+      report("DgZ7ToQ2DIConverter::DgZ7ToQ2DIConverter(): "
          "only implemented for aperture 3 hexagon grids", DgBase::Fatal);
    }
 
@@ -295,27 +298,31 @@ DgZ7StringToQ2DIConverter::DgZ7StringToQ2DIConverter
 
 ////////////////////////////////////////////////////////////////////////////////
 DgQ2DICoord
-DgZ7StringToQ2DIConverter::convertTypedAddress (const DgZ7StringCoord& addIn) const
+DgZ7ToQ2DIConverter::convertTypedAddress (const DgZ7Coord& addIn) const
 {
-   //printf("DgZ7StringToQ2DIConverter::convertTypedAddress\n");
+   //printf("DgZ7ToQ2DIConverter::convertTypedAddress\n");
 
-   string addstr = addIn.valString();
-   // first get the base cell number
-   string bstr = addstr.substr(0, 2);
-   if (bstr[0] == '0') // leading 0
-      bstr = bstr.substr(1, 1);
-   int bcNum = std::stoi(bstr);
+   uint64_t z7index = addIn.value();
+
+   // extract the z7 digits
+    uint8_t digits[21] = {};
+    int res = 20;
+    for (int r = 20; r > 0; --r) {
+        digits[r] = z7index & 0x7;
+        if (digits[r] == 0x7)
+            --res;
+        z7index >>= 3;
+    }
+    int bcNum = digits[0] = z7index & 0xF; // base cell number
+
     if (bcNum < 0 || bcNum > 11) {
-        report("DgZ7StringToQ2DIConverter::convertTypedAddress(): "
+        report("DgZ7ToQ2DIConverter::convertTypedAddress(): "
            "index has invalid base cell number", DgBase::Fatal);
-     }
+    }
 
-   // the rest is the Z7 digit string
-   int index = 2; // skip the two base cell digits
-   string z7str = addstr.substr(index);
-    int res = (int) z7str.length();
+   // first get the base cell number
     if (res != res_) {
-        report("DgZ7StringToQ2DIConverter::convertTypedAddress(): "
+        report("DgZ7ToQ2DIConverter::convertTypedAddress(): "
            "index does not match DGG resolution", DgBase::Fatal);
      }
 
@@ -325,13 +332,13 @@ DgZ7StringToQ2DIConverter::convertTypedAddress (const DgZ7StringCoord& addIn) co
 
    // adjust if Class III (odd res)
     if (res % 2) {
-        z7str += "0";
+        digits[res + 1] = 0;
         res++;
     }
 
    DgIVec3D ijk = { 0, 0, 0 };
-   for (int r = 0; r < res; r++) {
-       if ((r + 1) % 2) { // first res is 1, not 0
+   for (int r = 1; r <= res; r++) {
+       if (r % 2) {
            // Class III == rotate ccw
            ijk.downAp7();
        } else {
@@ -339,7 +346,7 @@ DgZ7StringToQ2DIConverter::convertTypedAddress (const DgZ7StringCoord& addIn) co
            ijk.downAp7r();
        }
 
-       ijk.neighbor((DgIVec3D::Direction) (z7str.c_str()[r] - '0'));
+       ijk.neighbor((DgIVec3D::Direction) digits[r]);
    }
 
    DgIVec2D ij = DgIVec2D(ijk);
@@ -496,7 +503,7 @@ DgZ7StringToQ2DIConverter::convertTypedAddress (const DgZ7StringCoord& addIn) co
 
    return q2di;
 
-} // DgQ2DICoord DgZ7StringToQ2DIConverter::convertTypedAddress
+} // DgQ2DICoord DgZ7ToQ2DIConverter::convertTypedAddress
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Note this is more of a draft. It presents an idea of how to improve performance when working with Z7 indexes, but likely needs more code reorganization, and if desired could be extended to Z3 indexing as well.

For cases where the Z7 string is not needed, a direct conversion to Z7 can be done instead, which in most cases is an optimization.

This changes:
* `DgQ2DItoZ7StringConverter` to `DgQ2DItoZ7Converter` and
* `DgZ7StringToQ2DIConverter` to `DgZ7ToQ2DIConverter`

And appropriately updates the `convertTypedAddress` member functions to generate or consume `DgZ7Coord`.

## Background

Using `dglib` for some experimenting in generating Z7 indexes, I was surprised to find `DgQ2DItoZ7StringConverter` as part of the converter from a `DgGeoSphDegRF` to `DgZ7RF`. Profiling conversion of 8 million locations I saw roughly 50% (~15 seconds) of the CPU time was in `DgQ2DItoZ7StringConverter::convertTypedAddress` related to the string manipulation/generation.

I noted that because there is a `Dg2WayZ7ToStringConverter`, switching to a `Q2DI` to/from `Z7` converter instead of to `Z7String` still maintained connectivity of all the frames in the network.

## Testing

I tested with dggrid using Intel vTune to profile CPU usage. I used the following configuration, testing with both `Z7` and `Z7_STRING` as the `output_address_type`. The input test file is over 80k points and is provided here 
[points.zip](https://github.com/user-attachments/files/23878790/points.zip)

```
dggrid_operation TRANSFORM_POINTS

dggs_type IGEO7
dggs_res_spec 16

input_file_name points.txt
input_address_type GEO
input_delimiter " "

output_address_type Z7_STRING
```

| `output_address_type` | Z7  | Z7_STRING  |
|--------------|------|-----|
| master        | 21.6 | 21.4 |
| this branch | 18.0 | 17.1 |

## Further work

If this seems acceptable, I think the converter should be moved to `DgZ7RF(.cpp/.h)` to take advantage of the Z7 related macros. Or alternately moved to it's own cpp/h, but if I'm understanding the projects organization, generally the focused converters are coupled with the RF implementations.

As mentioned above, this likely should be mirrored to `DgQ2DItoZ3StringConverter`/`DgZ3StringToQ2DIConverter` as it likely would benefit as well from working in bit-space during the conversion, as opposed to string-space.

