### PR TITLE
Replace the usage of `endl` with an explicit newline character

### DIFF
--- a/src/apps/dggrid/SubOpOut.cpp
+++ b/src/apps/dggrid/SubOpOut.cpp
@@ -70,6 +70,10 @@
 using namespace std;
 using namespace dgg::addtype;
 
+namespace {
+const char* newline = "\n";
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 void
 SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
@@ -99,7 +103,7 @@ SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
    if (op.mainOp.megaVerbose)
    {
       DgDVec2D tvec = cpv - cpv00;
-      dgcout << " " << tvec << endl;
+      dgcout << " " << tvec << newline;
    }
 
    DgDVec2D anchor;
@@ -111,7 +115,7 @@ SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
       ccRF.convert(verts);
       anchor = *ccRF.getAddress(verts[0]); // use lower left corner
    }
-   if (op.mainOp.megaVerbose) dgcout << "anchor: " << anchor << endl;
+   if (op.mainOp.megaVerbose) dgcout << "anchor: " << anchor << newline;
 
    for (int i = 0; i < nRandPts; i++)
    {
@@ -180,7 +184,7 @@ SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
                }
             }
 
-            if (op.mainOp.megaVerbose) dgcout << rp << endl;
+            if (op.mainOp.megaVerbose) dgcout << rp << newline;
          }
 
          rp += anchor;
@@ -196,7 +200,7 @@ SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
 
          delete tloc;
 
-         if (op.mainOp.megaVerbose) dgcout << "->" << *nloc << endl;
+         if (op.mainOp.megaVerbose) dgcout << "->" << *nloc << newline;
 
          rpts.push_back(*nloc);
          delete nloc;
@@ -205,15 +209,15 @@ SubOpOut::genRandPts (const DgQ2DICoord& add2D, const string& label)
 
    // convert
 
-   if (op.mainOp.megaVerbose) dgcout << "rpts: " << rpts << endl;
+   if (op.mainOp.megaVerbose) dgcout << "rpts: " << rpts << newline;
 
    dgg.geoRF().convert(rpts);
 
-   if (op.mainOp.megaVerbose) dgcout << "-> " << rpts << endl;
+   if (op.mainOp.megaVerbose) dgcout << "-> " << rpts << newline;
 
    deg.convert(rpts);
 
-   if (op.mainOp.megaVerbose) dgcout << "-> " << rpts << endl;
+   if (op.mainOp.megaVerbose) dgcout << "-> " << rpts << newline;
 
    DgLocList pts;
    for (int i = 0; i < rpts.size(); i++) {
@@ -273,9 +277,9 @@ SubOpOut::outputCellAdd2D (const DgLocation& add2D, const string* labelIn,
 
    // unwrap the cell east/west if applicable
    DgPolygon* unwrappedVerts = new DgPolygon(verts);
-   if (op.mainOp.megaVerbose) dgcout << "before unwrap: " << *unwrappedVerts << endl;
+   if (op.mainOp.megaVerbose) dgcout << "before unwrap: " << *unwrappedVerts << newline;
    int wrapped = DgGeoSphRF::lonWrap(*unwrappedVerts, lonWrapMode);
-   if (op.mainOp.megaVerbose) dgcout << "unwrapped: " << *unwrappedVerts << endl;
+   if (op.mainOp.megaVerbose) dgcout << "unwrapped: " << *unwrappedVerts << newline;
 
    // wrap the cell center point if the boundary was wrapped
    if (unwrapPts && wrapped) {
@@ -298,20 +302,20 @@ SubOpOut::outputCellAdd2D (const DgLocation& add2D, const string* labelIn,
 //  dgcout << std::setprecision(15);
 //  dgcout << label << " " << area << " "
 //       << area * dgg.geoRF().earthRadiusKM() * dgg.geoRF().earthRadiusKM()
-//       << endl;
+//       << newline;
 
    delete tmpLoc;
 
    if (op.mainOp.megaVerbose)
-      dgcout << "accepted " << label << " " << add2D << endl;
+      dgcout << "accepted " << label << " " << add2D << newline;
 
    if (dataOut)
-      *dataOut << label << op.primarySubOp->dataToOutStr(dataList) << endl;
+      *dataOut << label << op.primarySubOp->dataToOutStr(dataList) << newline;
 
    const DgQ2DICoord& q2di = *dgg.getAddress(add2D);
    if (cellOut) {
       if (op.mainOp.megaVerbose)
-         dgcout << "outputting region: " << cell << endl;
+         dgcout << "outputting region: " << cell << newline;
 
       if (prCellOut) {
          prCellOut->insert(cell.region(), &(cell.label()));
@@ -325,7 +329,7 @@ SubOpOut::outputCellAdd2D (const DgLocation& add2D, const string* labelIn,
 	
    if (ptOut) {
       if (op.mainOp.megaVerbose)
-         dgcout << "outputting point: " << cell << endl;
+         dgcout << "outputting point: " << cell << newline;
 
       if (outPointAttributes)
          ptOutShp->setCurFields(curFields);


### PR DESCRIPTION
As noted in https://github.com/sahrk/DGGRID/pull/95#issuecomment-3601381651, `std::endl` causes buffer flushes that aren't really necessary. The testing with ~80k points in #95 showed about 7 seconds (of ~20 second) of CPU time by `std::endl` usage in `SubOpOut.cpp`. Replacing these with an explicit newline character eliminates those 7 seconds.