### PR TITLE
Big cleanup: Modern insertParam API with initializer_list and vector<…

### DIFF
--- a/src/apps/dggrid/SubOpBinPts.cpp
+++ b/src/apps/dggrid/SubOpBinPts.cpp
@@ -155,21 +155,13 @@ SubOpBinPts::outputCell(const DgLocation& loc, const Val& val) const
 int
 SubOpBinPts::initializeOp (void) {
 
-   std::vector<std::string*> choices;
-
 /* not yet used
    // bin_method <ARITHMETIC_MEAN>
-   choices.push_back(new std::string("ARITHMETIC_MEAN"));
-   pList().insertParam(new DgStringChoiceParam("bin_method", "ARITHMETIC_MEAN",
-                                       &choices));
-   dgg::util::release(choices);
+   pList().insertParam("bin_method", "ARITHMETIC_MEAN", {"ARITHMETIC_MEAN"});
 */
 
    // bin_coverage <GLOBAL | PARTIAL>
-   choices.push_back(new std::string("GLOBAL"));
-   choices.push_back(new std::string("PARTIAL"));
-   pList().insertParam(new DgStringChoiceParam("bin_coverage", "GLOBAL", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("bin_coverage", "GLOBAL", {"GLOBAL", "PARTIAL"});
 
    // output_count <TRUE | FALSE>
    pList().insertParam(new DgBoolParam("output_count", false));
@@ -207,11 +199,8 @@ SubOpBinPts::initializeOp (void) {
 
 
    // cell_output_control <OUTPUT_ALL | OUTPUT_OCCUPIED>
-   choices.push_back(new std::string("OUTPUT_ALL"));
-   choices.push_back(new std::string("OUTPUT_OCCUPIED"));
-   pList().insertParam(new DgStringChoiceParam("cell_output_control", "OUTPUT_ALL",
-                                       &choices));
-   dgg::util::release(choices);
+   pList().insertParam("cell_output_control", "OUTPUT_ALL",
+                       {"OUTPUT_ALL", "OUTPUT_OCCUPIED"});
 
    return 0;
 

--- a/src/apps/dggrid/SubOpDGG.cpp
+++ b/src/apps/dggrid/SubOpDGG.cpp
@@ -163,64 +163,28 @@ SubOpDGG::addressTypeToRF (DgAddressType type, DgHierNdxSysType hierNdxSysType, 
 int
 SubOpDGG::initializeOp (void)
 {
-   std::vector<std::string*> choices;
-
    // dggs_type <CUSTOM | SUPERFUND | PLANETRISK | IGEO7 |
    //            ISEA3H | ISEA4H | ISEA7H | ISEA43H | ISEA4T | ISEA4D |
    //            FULLER3H | FULLER4H | FULLER7H | FULLER43H | FULLER4T | FULLER4D>
-   choices.push_back(new std::string("CUSTOM"));
-   choices.push_back(new std::string("SUPERFUND"));
-   choices.push_back(new std::string("PLANETRISK"));
-   choices.push_back(new std::string("IGEO7"));
-   choices.push_back(new std::string("ISEA3H"));
-   choices.push_back(new std::string("ISEA4H"));
-   choices.push_back(new std::string("ISEA7H"));
-   choices.push_back(new std::string("ISEA43H"));
-   choices.push_back(new std::string("ISEA4T"));
-   choices.push_back(new std::string("ISEA4D"));
-   choices.push_back(new std::string("FULLER3H"));
-   choices.push_back(new std::string("FULLER4H"));
-   choices.push_back(new std::string("FULLER7H"));
-   choices.push_back(new std::string("FULLER43H"));
-   choices.push_back(new std::string("FULLER4T"));
-   choices.push_back(new std::string("FULLER4D"));
-   pList().insertParam(new DgStringChoiceParam("dggs_type", "CUSTOM", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_type", "CUSTOM",
+       {"CUSTOM", "SUPERFUND", "PLANETRISK", "IGEO7",
+        "ISEA3H", "ISEA4H", "ISEA7H", "ISEA43H", "ISEA4T", "ISEA4D",
+        "FULLER3H", "FULLER4H", "FULLER7H", "FULLER43H", "FULLER4T", "FULLER4D"});
 
    // dggs_base_poly <ICOSAHEDRON>
-   choices.push_back(new std::string("ICOSAHEDRON"));
-   pList().insertParam(new DgStringChoiceParam("dggs_base_poly", "ICOSAHEDRON",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_base_poly", "ICOSAHEDRON", {"ICOSAHEDRON"});
 
    // dggs_topology <HEXAGON | TRIANGLE | DIAMOND>
-   choices.push_back(new std::string("HEXAGON"));
-   choices.push_back(new std::string("TRIANGLE"));
-   choices.push_back(new std::string("DIAMOND"));
-   pList().insertParam(new DgStringChoiceParam("dggs_topology", "HEXAGON", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_topology", "HEXAGON", {"HEXAGON", "TRIANGLE", "DIAMOND"});
 
    // dggs_proj <ISEA | FULLER | GNOMONIC>
-   choices.push_back(new std::string("ISEA"));
-   choices.push_back(new std::string("FULLER"));
-   //choices.push_back(new std::string("GNOMONIC"));
-   pList().insertParam(new DgStringChoiceParam("dggs_proj", "ISEA", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_proj", "ISEA", {"ISEA", "FULLER" /*, "GNOMONIC"*/ });
 
    // dggs_aperture_type <PURE | MIXED43 | SEQUENCE>
-   choices.push_back(new std::string("PURE"));
-   choices.push_back(new std::string("MIXED43"));
-   choices.push_back(new std::string("SEQUENCE"));
-   pList().insertParam(new DgStringChoiceParam("dggs_aperture_type", "PURE",
-             &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_aperture_type", "PURE", {"PURE", "MIXED43", "SEQUENCE"});
 
    // dggs_aperture < 3 | 4 | 7 >
-   choices.push_back(new std::string("3"));
-   choices.push_back(new std::string("4"));
-   choices.push_back(new std::string("7"));
-   pList().insertParam(new DgStringChoiceParam("dggs_aperture", "4", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_aperture", "4", {"3", "4", "7"});
 
    // dggs_aperture_sequence < apertureSequence >
    pList().insertParam(new DgStringParam("dggs_aperture_sequence",
@@ -235,12 +199,8 @@ SubOpDGG::initializeOp (void)
    pList().insertParam(new DgIntParam("dggs_num_aperture_4_res", 0, 0, MAX_DGG_RES));
 
    // proj_datum <WGS84_AUTHALIC_SPHERE WGS84_MEAN_SPHERE CUSTOM_SPHERE>
-   choices.push_back(new std::string("WGS84_AUTHALIC_SPHERE"));
-   choices.push_back(new std::string("WGS84_MEAN_SPHERE"));
-   choices.push_back(new std::string("CUSTOM_SPHERE"));
-   pList().insertParam(new DgStringChoiceParam("proj_datum",
-               "WGS84_AUTHALIC_SPHERE", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("proj_datum", "WGS84_AUTHALIC_SPHERE",
+                       {"WGS84_AUTHALIC_SPHERE", "WGS84_MEAN_SPHERE", "CUSTOM_SPHERE"});
 
    // proj_datum_radius <long double: km> (1.0 <= v <= 10000.0)
    pList().insertParam(new DgDoubleParam("proj_datum_radius", DEFAULT_RADIUS_KM,
@@ -249,12 +209,8 @@ SubOpDGG::initializeOp (void)
    //// specify the position and orientation
 
    // dggs_orient_specify_type <RANDOM | SPECIFIED | REGION_CENTER>
-   choices.push_back(new std::string("RANDOM"));
-   choices.push_back(new std::string("SPECIFIED"));
-   choices.push_back(new std::string("REGION_CENTER"));
-   pList().insertParam(new DgStringChoiceParam("dggs_orient_specify_type", "SPECIFIED",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_orient_specify_type", "SPECIFIED",
+                       {"RANDOM", "SPECIFIED", "REGION_CENTER"});
 
    // dggs_num_placements <int> (v >= 1)
    pList().insertParam(new DgIntParam("dggs_num_placements", 1, 1, INT_MAX, true));
@@ -279,12 +235,8 @@ SubOpDGG::initializeOp (void)
    pList().insertParam(new DgDoubleParam("region_center_lat", 0.0, -90.0, 90.0));
 
    // dggs_res_specify_type <SPECIFIED | CELL_AREA | INTERCELL_DISTANCE>
-   choices.push_back(new std::string("SPECIFIED"));
-   choices.push_back(new std::string("CELL_AREA"));
-   choices.push_back(new std::string("INTERCELL_DISTANCE"));
-   pList().insertParam(new DgStringChoiceParam("dggs_res_specify_type", "SPECIFIED",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggs_res_specify_type", "SPECIFIED",
+                       {"SPECIFIED", "CELL_AREA", "INTERCELL_DISTANCE"});
 
    // dggs_res_specify_area <long double: km^2> (v > 0.0)
    pList().insertParam(new DgDoubleParam("dggs_res_specify_area", 100.0,
@@ -301,24 +253,12 @@ SubOpDGG::initializeOp (void)
    pList().insertParam(new DgIntParam("dggs_res_spec", 9, 0, MAX_DGG_RES));
 
    // hier_indexing_system_type <ZORDER | Z3 | Z7 | NONE>
-   for (int i = 0; ; i++) {
-       choices.push_back(new std::string(dgg::addtype::hierNdxSysTypeStrings[i]));
-       if (dgg::addtype::hierNdxSysTypeStrings[i] == "NONE")
-          break;
-   }
-   pList().insertParam(new DgStringChoiceParam("hier_indexing_system_type", "NONE", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("hier_indexing_system_type", "NONE",
+                       dgg::addtype::hierNdxSysTypeChoices());
 
    // z3_invalid_digit < 0 | 1 | 2 | 3 >
-   choices.push_back(new std::string("0"));
-   choices.push_back(new std::string("1"));
-   choices.push_back(new std::string("2"));
-   choices.push_back(new std::string("3"));
-// default changed to "3" in version 9.0b
-   //pList().insertParam(new DgStringChoiceParam("z3_invalid_digit", "0",
-   pList().insertParam(new DgStringChoiceParam("z3_invalid_digit", "3",
-             &choices));
-   dgg::util::release(choices);
+   // default changed to "3" in version 9.0b
+   pList().insertParam("z3_invalid_digit", "3", {"0", "1", "2", "3"});
 
    return 0;
 

--- a/src/apps/dggrid/SubOpDGG.cpp
+++ b/src/apps/dggrid/SubOpDGG.cpp
@@ -254,7 +254,7 @@ SubOpDGG::initializeOp (void)
 
    // hier_indexing_system_type <ZORDER | Z3 | Z7 | NONE>
    pList().insertParam("hier_indexing_system_type", "NONE",
-                       dgg::addtype::hierNdxSysTypeChoices());
+                       {"Z7", "ZORDER", "Z3", "NONE"});
 
    // z3_invalid_digit < 0 | 1 | 2 | 3 >
    // default changed to "3" in version 9.0b

--- a/src/apps/dggrid/SubOpGen.cpp
+++ b/src/apps/dggrid/SubOpGen.cpp
@@ -96,8 +96,6 @@ SubOpGen::SubOpGen (OpBasic& op, bool _activate)
 int
 SubOpGen::initializeOp (void)
 {
-   std::vector<std::string*> choices;
-
 #ifdef USE_GDAL
    // clip_using_holes <TRUE | FALSE>
    pList().insertParam(new DgBoolParam("clip_using_holes", false));
@@ -116,18 +114,14 @@ SubOpGen::initializeOp (void)
    // KEVIN: currently no ADDRESSES or COARSE_CELL_FILES
    // clip_subset_type <WHOLE_EARTH | AIGEN | SHAPEFILE | GDAL |
    //                   ADDRESS_FILES | COARSE_CELLS >
-   choices.push_back(new std::string("WHOLE_EARTH"));
-   choices.push_back(new std::string("AIGEN"));
-   choices.push_back(new std::string("SHAPEFILE"));
+   {
+      std::vector<std::string> ch = {"WHOLE_EARTH", "AIGEN", "SHAPEFILE",
+                                     "ADDRESS_FILES", "INPUT_ADDRESS_TYPE", "COARSE_CELLS"};
 #ifdef USE_GDAL
-   choices.push_back(new std::string("GDAL"));
+      ch.insert(ch.begin() + 3, "GDAL");
 #endif
-   choices.push_back(new std::string("ADDRESS_FILES"));
-   choices.push_back(new std::string("INPUT_ADDRESS_TYPE")); // deprecated; same as ADDRESS_FILES
-   choices.push_back(new std::string("COARSE_CELLS"));
-   pList().insertParam(new DgStringChoiceParam("clip_subset_type", "WHOLE_EARTH",
-               &choices));
-   dgg::util::release(choices);
+      pList().insertParam(new DgStringChoiceParam("clip_subset_type", "WHOLE_EARTH", ch));
+   }
 
    // clip_cell_addresses <clipCell1 clipCell2 ... clipCellN>
    pList().insertParam(new DgStringParam("clip_cell_addresses", ""));
@@ -142,10 +136,7 @@ SubOpGen::initializeOp (void)
    pList().insertParam(new DgStringParam("clip_region_files", "test.gen"));
 
    // clip_type <POLY_INTERSECT>
-   choices.push_back(new std::string("POLY_INTERSECT"));
-   pList().insertParam(new DgStringChoiceParam("clip_type", "POLY_INTERSECT",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("clip_type", "POLY_INTERSECT", {"POLY_INTERSECT"});
 
    // clipper_scale_factor <unsigned long int>
    pList().insertParam(new DgULIntParam("clipper_scale_factor", 1000000L, 1, ULONG_MAX, true));

--- a/src/apps/dggrid/SubOpIn.cpp
+++ b/src/apps/dggrid/SubOpIn.cpp
@@ -98,8 +98,8 @@ SubOpIn::initializeOp (void)
 
     // input_hier_ndx_system < ZORDER | Z3 | Z7 >
     // used if input_address_type is HIERNDX
-    pList().insertParam("input_hier_ndx_system", "Z3",
-                        dgg::addtype::hierNdxSysTypeChoices());
+   pList().insertParam("input_hier_ndx_system", "Z3",
+                       {"Z7", "ZORDER", "Z3", "NONE"});
 
     // input_hier_ndx_form < INT64 | DIGIT_STRING | NONE >
     // used if input_address_type is HIERNDX

--- a/src/apps/dggrid/SubOpIn.cpp
+++ b/src/apps/dggrid/SubOpIn.cpp
@@ -49,8 +49,6 @@ SubOpIn::SubOpIn (OpBasic& op, bool _activate)
 int
 SubOpIn::initializeOp (void)
 {
-   std::vector<std::string*> choices;
-
    // input_files <fileName1 fileName2 ... fileNameN>
    pList().insertParam(new DgStringParam("input_files", "vals.txt"));
 
@@ -65,12 +63,10 @@ SubOpIn::initializeOp (void)
       choices.push_back(new std::string("FIRST_FIELD"));
       choices.push_back(new std::string("NAMED_FIELD"));
 */
-      choices.push_back(new std::string("GEO_POINT")); // determines the index from the input point geometry
-                                               // note this differs from having a geo point in a (text)
-                                               // field (that is the intent when fully implemented)
-      pList().insertParam(new DgStringChoiceParam("input_address_field_type", "GEO_POINT",
-                  &choices));
-      dgg::util::release(choices);
+      // determines the index from the input point geometry
+      // note this differs from having a geo point in a (text)
+      // field (that is the intent when fully implemented)
+      pList().insertParam("input_address_field_type", "GEO_POINT", {"GEO_POINT"});
 /*
       // input_address_field_name <fieldName>
       // used when input_address_field_type is NAMED_FIELD
@@ -78,14 +74,14 @@ SubOpIn::initializeOp (void)
    }
 */
    // point_input_file_type <NONE | TEXT | GDAL>
-   choices.push_back(new std::string("NONE"));
+   {
+      std::vector<std::string> ch = {"NONE", "TEXT"};
 #ifdef USE_GDAL
-   choices.push_back(new std::string("GDAL"));
+      ch.push_back("GDAL");
 #endif
-   choices.push_back(new std::string("TEXT"));
-   std::string def = ((op.mainOp.operation == "GENERATE_GRID") ? "NONE" : "TEXT");
-   pList().insertParam(new DgStringChoiceParam("point_input_file_type", def, &choices));
-   dgg::util::release(choices);
+      std::string def = ((op.mainOp.operation == "GENERATE_GRID") ? "NONE" : "TEXT");
+      pList().insertParam("point_input_file_type", def, ch);
+   }
 
 /*
 #ifdef USE_GDAL
@@ -96,38 +92,19 @@ SubOpIn::initializeOp (void)
 
    // input_address_type < GEO | PLANE | PROJTRI | Q2DD | Q2DI |
    //        SEQNUM | VERTEX2DD | HIERNDX >
-   for (int i = 0; ; i++) {
-      if (dgg::addtype::addTypeStrings[i] == "NONE")
-         break;
-      choices.push_back(new std::string(dgg::addtype::addTypeStrings[i]));
-   }
-
    // KEVIN?? def = ((op.mainOp.operation != "TRANSFORM_POINTS") ? "GEO" : "SEQNUM");
-   def = "GEO";
-   pList().insertParam(new DgStringChoiceParam("input_address_type", def, &choices));
-   dgg::util::release(choices);
+   pList().insertParam("input_address_type", "GEO",
+                       dgg::addtype::addressTypeChoices());
 
     // input_hier_ndx_system < ZORDER | Z3 | Z7 >
     // used if input_address_type is HIERNDX
-    for (int i = 0; ; i++) {
-       choices.push_back(new std::string(dgg::addtype::hierNdxSysTypeStrings[i]));
-       if (dgg::addtype::hierNdxSysTypeStrings[i] == "NONE")
-          break;
-    }
-    def = "Z3";
-    pList().insertParam(new DgStringChoiceParam("input_hier_ndx_system", def, &choices));
-    dgg::util::release(choices);
+    pList().insertParam("input_hier_ndx_system", "Z3",
+                        dgg::addtype::hierNdxSysTypeChoices());
 
     // input_hier_ndx_form < INT64 | DIGIT_STRING | NONE >
     // used if input_address_type is HIERNDX
-    for (int i = 0; ; i++) {
-       choices.push_back(new std::string(dgg::addtype::hierNdxFormTypeStrings[i]));
-       if (dgg::addtype::hierNdxFormTypeStrings[i] == "NONE")
-          break;
-    }
-    def = "INT64";
-    pList().insertParam(new DgStringChoiceParam("input_hier_ndx_form", def, &choices));
-    dgg::util::release(choices);
+    pList().insertParam("input_hier_ndx_form", "INT64",
+                        dgg::addtype::hierNdxFormTypeChoices());
 
    // input_delimiter <v is any character in long double quotes>
    pList().insertParam(new DgStringParam("input_delimiter", "\" \"", true ,false));

--- a/src/apps/dggrid/SubOpIn.cpp
+++ b/src/apps/dggrid/SubOpIn.cpp
@@ -103,8 +103,8 @@ SubOpIn::initializeOp (void)
 
     // input_hier_ndx_form < INT64 | DIGIT_STRING | NONE >
     // used if input_address_type is HIERNDX
-    pList().insertParam("input_hier_ndx_form", "INT64",
-                        dgg::addtype::hierNdxFormTypeChoices());
+   pList().insertParam("input_hier_ndx_form", "INT64",
+                       {"INT64", "DIGIT_STRING", "NONE"});
 
    // input_delimiter <v is any character in long double quotes>
    pList().insertParam(new DgStringParam("input_delimiter", "\" \"", true ,false));

--- a/src/apps/dggrid/SubOpMain.cpp
+++ b/src/apps/dggrid/SubOpMain.cpp
@@ -40,25 +40,14 @@ SubOpMain::SubOpMain (OpBasic& op, bool _activate)
 int
 SubOpMain::initializeOp (void)
 {
-   std::vector<std::string*> choices;
-
    // dggrid_operation <GENERATE_GRID | GENERATE_GRID_FROM_POINTS |
    //     BIN_POINT_VALS | BIN_POINT_PRESENCE | TRANSFORM_POINTS | OUTPUT_STATS>
-   choices.push_back(new std::string("GENERATE_GRID"));
-   choices.push_back(new std::string("GENERATE_GRID_FROM_POINTS"));
-   choices.push_back(new std::string("BIN_POINT_VALS"));
-   choices.push_back(new std::string("BIN_POINT_PRESENCE"));
-   choices.push_back(new std::string("TRANSFORM_POINTS"));
-   choices.push_back(new std::string("OUTPUT_STATS"));
-   pList().insertParam(new DgStringChoiceParam("dggrid_operation", "GENERATE_GRID",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("dggrid_operation", "GENERATE_GRID",
+       {"GENERATE_GRID", "GENERATE_GRID_FROM_POINTS", "BIN_POINT_VALS",
+        "BIN_POINT_PRESENCE", "TRANSFORM_POINTS", "OUTPUT_STATS"});
 
    // rng_type <RAND | MOTHER>
-   choices.push_back(new std::string("RAND"));
-   choices.push_back(new std::string("MOTHER"));
-   pList().insertParam(new DgStringChoiceParam("rng_type", "RAND", &choices));
-   dgg::util::release(choices);
+   pList().insertParam("rng_type", "RAND", {"RAND", "MOTHER"});
 
    // precision <int> (0 <= v <= 30)
    pList().insertParam(new DgIntParam("precision", DEFAULT_PRECISION, 0, INT_MAX));

--- a/src/apps/dggrid/SubOpOut.cpp
+++ b/src/apps/dggrid/SubOpOut.cpp
@@ -444,57 +444,33 @@ SubOpOut::SubOpOut (OpBasic& op, bool _activate)
 int
 SubOpOut::initializeOp (void)
 {
-   std::vector<std::string*> choices;
    std::string def;
 
    // output_file_name <fileName>
    pList().insertParam(new DgStringParam("output_file_name", "valsout.txt"));
 
    // output_file_type <NONE | TEXT >
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("TEXT"));
-
    def = ((op.mainOp.operation == "BIN_POINT_VALS" ||
            op.mainOp.operation == "BIN_POINT_PRESENCE" ||
            op.mainOp.operation == "TRANSFORM_POINTS") ? "TEXT" : "NONE");
    //def = "NONE";
-   pList().insertParam(new DgStringChoiceParam("output_file_type", def,
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("output_file_type", def, {"NONE", "TEXT"});
 
    // output_address_type < GEO | PLANE | PROJTRI | Q2DD | Q2DI |
    //        SEQNUM | VERTEX2DD | HIERNDX >
    // KEVIN: still supports version 8 z* types
-    for (int i = 0; ; i++) {
-       if (dgg::addtype::addTypeStrings[i] == "NONE")
-          break;
-       choices.push_back(new std::string(dgg::addtype::addTypeStrings[i]));
-    }
-    pList().insertParam(new DgStringChoiceParam("output_address_type",
-                "SEQNUM", &choices));
-    dgg::util::release(choices);
+   pList().insertParam("output_address_type", "SEQNUM",
+                       dgg::addtype::addressTypeChoices());
 
     // output_hier_ndx_system < ZORDER | Z3 | Z7 >
     // used if output_address_type is HIERNDX
-    for (int i = 0; ; i++) {
-       if (dgg::addtype::hierNdxSysTypeStrings[i] == "NONE")
-          break;
-       choices.push_back(new std::string(dgg::addtype::hierNdxSysTypeStrings[i]));
-    }
-    def = "Z3";
-    pList().insertParam(new DgStringChoiceParam("output_hier_ndx_system", def, &choices));
-    dgg::util::release(choices);
+    pList().insertParam("output_hier_ndx_system", "Z3",
+                        dgg::addtype::hierNdxSysTypeChoices());
 
     // output_hier_ndx_form < INT64 | DIGIT_STRING >
     // used if output_address_type is HIERNDX
-    for (int i = 0; ; i++) {
-       if (dgg::addtype::hierNdxFormTypeStrings[i] == "NONE")
-          break;
-       choices.push_back(new std::string(dgg::addtype::hierNdxFormTypeStrings[i]));
-    }
-    def = "INT64";
-    pList().insertParam(new DgStringChoiceParam("output_hier_ndx_form", def, &choices));
-    dgg::util::release(choices);
+    pList().insertParam("output_hier_ndx_form", "INT64",
+                        dgg::addtype::hierNdxFormTypeChoices());
 
     // output_delimiter <v is any character in double quotes>
     pList().insertParam(new DgStringParam("output_delimiter", "\" \"", true, false));
@@ -503,73 +479,51 @@ SubOpOut::initializeOp (void)
     pList().insertParam(new DgIntParam("densification", 0, 0, 500));
 
    // longitude_wrap_mode < WRAP | UNWRAP_WEST | UNWRAP_EAST >
-   choices.push_back(new std::string("WRAP"));
-   choices.push_back(new std::string("UNWRAP_WEST"));
-   choices.push_back(new std::string("UNWRAP_EAST"));
-   pList().insertParam(new DgStringChoiceParam("longitude_wrap_mode", "WRAP",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("longitude_wrap_mode", "WRAP",
+                       {"WRAP", "UNWRAP_WEST", "UNWRAP_EAST"});
 
    // unwrap_points <TRUE | FALSE> (true indicates unwrap center point
    //        longitude to match the cell boundary, false allow to wrap)
    pList().insertParam(new DgBoolParam("unwrap_points", true));
 
    // output_cell_label_type <GLOBAL_SEQUENCE | ENUMERATION | SUPERFUND | OUTPUT_ADDRESS_TYPE >
-   choices.push_back(new std::string("GLOBAL_SEQUENCE"));
-   choices.push_back(new std::string("ENUMERATION"));
-   choices.push_back(new std::string("SUPERFUND"));
-   choices.push_back(new std::string("OUTPUT_ADDRESS_TYPE"));
-
-   std::string outLblDef("GLOBAL_SEQUENCE");
-   if (op.mainOp.operation == "TRANSFORM_POINTS")
-      outLblDef = "OUTPUT_ADDRESS_TYPE";
-   pList().insertParam(new DgStringChoiceParam("output_cell_label_type", outLblDef,
-               &choices));
-   dgg::util::release(choices);
+   {
+      std::string outLblDef("GLOBAL_SEQUENCE");
+      if (op.mainOp.operation == "TRANSFORM_POINTS")
+         outLblDef = "OUTPUT_ADDRESS_TYPE";
+      pList().insertParam("output_cell_label_type", outLblDef,
+          {"GLOBAL_SEQUENCE", "ENUMERATION", "SUPERFUND", "OUTPUT_ADDRESS_TYPE"});
+   }
 
    ////// output parameters //////
 
    // cell_output_type <NONE | AIGEN | GDAL | KML | GEOJSON | SHAPEFILE | GDAL_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("AIGEN"));
+   {
+      std::vector<std::string> ch = {"NONE", "AIGEN", "KML", "GEOJSON", "SHAPEFILE", "GDAL_COLLECTION"};
 #ifdef USE_GDAL
-   choices.push_back(new std::string("GDAL"));
+      ch.insert(ch.begin() + 2, "GDAL");
 #endif
-   choices.push_back(new std::string("KML"));
-   choices.push_back(new std::string("GEOJSON"));
-   choices.push_back(new std::string("SHAPEFILE"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   //choices.push_back(new std::string("TEXT"));
-   def = ((op.mainOp.operation == "GENERATE_GRID") ? "AIGEN" : "NONE");
-   pList().insertParam(new DgStringChoiceParam("cell_output_type", def, &choices));
-   dgg::util::release(choices);
+      def = ((op.mainOp.operation == "GENERATE_GRID") ? "AIGEN" : "NONE");
+      pList().insertParam("cell_output_type", def, ch);
+   }
 
    // point_output_type <NONE | AIGEN | GDAL | KML | GEOJSON | SHAPEFILE | TEXT | GDAL_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("AIGEN"));
+   {
+      std::vector<std::string> ch = {"NONE", "AIGEN", "KML", "GEOJSON", "SHAPEFILE", "TEXT", "GDAL_COLLECTION"};
 #ifdef USE_GDAL
-   choices.push_back(new std::string("GDAL"));
+      ch.insert(ch.begin() + 2, "GDAL");
 #endif
-   choices.push_back(new std::string("KML"));
-   choices.push_back(new std::string("GEOJSON"));
-   choices.push_back(new std::string("SHAPEFILE"));
-   choices.push_back(new std::string("TEXT"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   pList().insertParam(new DgStringChoiceParam("point_output_type", "NONE", &choices));
-   dgg::util::release(choices);
+      pList().insertParam("point_output_type", "NONE", ch);
+   }
 
    // randpts_output_type <NONE | AIGEN | GDAL | KML | GEOJSON | SHAPEFILE | TEXT>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("AIGEN"));
+   {
+      std::vector<std::string> ch = {"NONE", "AIGEN", "KML", "SHAPEFILE", "GEOJSON", "TEXT"};
 #ifdef USE_GDAL
-   choices.push_back(new std::string("GDAL"));
+      ch.insert(ch.begin() + 2, "GDAL");
 #endif
-   choices.push_back(new std::string("KML"));
-   choices.push_back(new std::string("SHAPEFILE"));
-   choices.push_back(new std::string("GEOJSON"));
-   choices.push_back(new std::string("TEXT"));
-   pList().insertParam(new DgStringChoiceParam("randpts_output_type", "NONE", &choices));
-   dgg::util::release(choices);
+      pList().insertParam("randpts_output_type", "NONE", ch);
+   }
 
 #ifdef USE_GDAL
    // cell_output_gdal_format <gdal driver type>
@@ -580,7 +534,6 @@ SubOpOut::initializeOp (void)
 
    // collection_output_gdal_format <gdal driver type>
    pList().insertParam(new DgStringParam("collection_output_gdal_format", "GeoJSON"));
-
 #endif
 
    // cell_output_file_name <outputFileName>
@@ -618,46 +571,30 @@ SubOpOut::initializeOp (void)
    pList().insertParam(new DgStringParam("kml_description",
                DgOutLocFile::defaultKMLDescription));
 
-   // neighbor_output_type <NONE | TEXT | GEOJSON_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("TEXT"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   pList().insertParam(new DgStringChoiceParam("neighbor_output_type", "NONE",
-               &choices));
-   dgg::util::release(choices);
+   // neighbor_output_type <NONE | TEXT | GDAL_COLLECTION>
+   pList().insertParam("neighbor_output_type", "NONE",
+                       {"NONE", "TEXT", "GDAL_COLLECTION"});
 
    // neighbor_output_file_name <outputFileName>
    pList().insertParam(new DgStringParam("neighbor_output_file_name", "nbr"));
 
    // children_output_type <NONE | TEXT | GDAL_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("TEXT"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   pList().insertParam(new DgStringChoiceParam("children_output_type", "NONE",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("children_output_type", "NONE",
+                       {"NONE", "TEXT", "GDAL_COLLECTION"});
 
    // children_output_file_name <outputFileName>
    pList().insertParam(new DgStringParam("children_output_file_name", "chld"));
 
    // indexing_children_output_type <NONE | TEXT | GDAL_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("TEXT"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   pList().insertParam(new DgStringChoiceParam("indexing_children_output_type", "NONE",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("indexing_children_output_type", "NONE",
+                       {"NONE", "TEXT", "GDAL_COLLECTION"});
 
    // indexing_children_output_file_name <outputFileName>
    pList().insertParam(new DgStringParam("indexing_children_output_file_name", "ndxChld"));
 
    // indexing_parent_output_type <NONE | TEXT | GDAL_COLLECTION>
-   choices.push_back(new std::string("NONE"));
-   choices.push_back(new std::string("TEXT"));
-   choices.push_back(new std::string("GDAL_COLLECTION"));
-   pList().insertParam(new DgStringChoiceParam("indexing_parent_output_type", "NONE",
-               &choices));
-   dgg::util::release(choices);
+   pList().insertParam("indexing_parent_output_type", "NONE",
+                       {"NONE", "TEXT", "GDAL_COLLECTION"});
 
    // indexing_parent_output_file_name <outputFileName>
    pList().insertParam(new DgStringParam("indexing_parent_output_file_name", "ndxPrt"));

--- a/src/lib/dgaplib/include/dgaplib/DgApParamList.h
+++ b/src/lib/dgaplib/include/dgaplib/DgApParamList.h
@@ -31,6 +31,7 @@
 
 #include <cfloat>
 #include <climits>
+#include <initializer_list>
 #include <string>
 #include <vector>
 
@@ -139,6 +140,16 @@ class DgApParamList {
                  bool failSilent = false);
 
       void insertParam (DgApAssoc* param); // does not make a copy
+
+      /// Convenience overload for the common DgStringChoiceParam case.
+      void insertParam (const std::string& name,
+                        const std::string& defaultValue,
+                        std::initializer_list<std::string> choices);
+
+      /// Convenience overload accepting std::vector<std::string>.
+      void insertParam (const std::string& name,
+                        const std::string& defaultValue,
+                        const std::vector<std::string>& choices);
 
       DgApAssoc* getParam (const std::string& nameIn,
                          bool setToIsApplicable = true) const;
@@ -567,6 +578,20 @@ class DgChoiceParam : public DgParameter<T> {
            addChoices(*choicesIn);
       }
 
+      DgChoiceParam (const std::string& nameIn, std::initializer_list<T> choicesIn)
+          : DgParameter<T> (nameIn) { addChoices(choicesIn); }
+
+      DgChoiceParam (const std::string& nameIn, const T& valIn,
+                     std::initializer_list<T> choicesIn, bool validIn = true)
+        : DgParameter<T> (nameIn, valIn, validIn) { addChoices(choicesIn); }
+
+      DgChoiceParam (const std::string& nameIn, const std::vector<T>& choicesIn)
+          : DgParameter<T> (nameIn) { addChoices(choicesIn); }
+
+      DgChoiceParam (const std::string& nameIn, const T& valIn,
+                     const std::vector<T>& choicesIn, bool validIn = true)
+        : DgParameter<T> (nameIn, valIn, validIn) { addChoices(choicesIn); }
+
      ~DgChoiceParam (void)
            { clearChoices(); }
 
@@ -575,7 +600,21 @@ class DgChoiceParam : public DgParameter<T> {
       void addChoices (const std::vector<T*>& choicesIn) // makes copy
             {
                for (unsigned int i = 0; i < choicesIn.size(); i++) {
-                  choices_.push_back(new std::string(*choicesIn[i]));
+                  choices_.push_back(new T(*choicesIn[i]));
+               }
+            }
+
+      void addChoices (std::initializer_list<T> choicesIn)
+            {
+               for (const auto& c : choicesIn) {
+                  choices_.push_back(new T(c));
+               }
+            }
+
+      void addChoices (const std::vector<T>& choicesIn) // makes copy
+            {
+               for (const auto& c : choicesIn) {
+                  choices_.push_back(new T(c));
                }
             }
 
@@ -628,19 +667,13 @@ class DgStringChoiceParam : public DgChoiceParam<std::string> {
       DgStringChoiceParam (const std::string& nameIn,
                            const std::vector<std::string*>* choicesIn = 0)
           : DgChoiceParam<std::string> (nameIn, choicesIn)
-                {
-                   for (unsigned int i = 0; i < choices_.size(); i++) {
-                      *choices_[i] = toLower(*choices_[i]);
-                   }
-                }
+                { lowerChoices(); }
 
       DgStringChoiceParam (const std::string& nameIn, const std::string& valIn,
                      const std::vector<std::string*>* choicesIn = 0, bool validIn = true)
           : DgChoiceParam<std::string> (nameIn, valIn, choicesIn, validIn)
                 {
-                   for (unsigned int i = 0; i < choices_.size(); i++) {
-                      *choices_[i] = toLower(*choices_[i]);
-                   }
+                   lowerChoices();
 
                    if (!validate()) {
                      report(
@@ -649,6 +682,54 @@ class DgStringChoiceParam : public DgChoiceParam<std::string> {
                         validationErrMsg(), DgBase::Fatal);
                    }
                 }
+
+      DgStringChoiceParam (const std::string& nameIn,
+                           std::initializer_list<std::string> choicesIn)
+          : DgChoiceParam<std::string> (nameIn, choicesIn)
+                { lowerChoices(); }
+
+      DgStringChoiceParam (const std::string& nameIn, const std::string& valIn,
+                           std::initializer_list<std::string> choicesIn,
+                           bool validIn = true)
+          : DgChoiceParam<std::string> (nameIn, valIn, choicesIn, validIn)
+                {
+                   lowerChoices();
+
+                   if (!validate()) {
+                     report(
+                       std::string("Invalid initialization data for parameter:\n")
+                        + name() + " " + valToStr() +std::string("\n") +
+                        validationErrMsg(), DgBase::Fatal);
+                   }
+                }
+
+      DgStringChoiceParam (const std::string& nameIn,
+                           const std::vector<std::string>& choicesIn)
+          : DgChoiceParam<std::string> (nameIn, choicesIn)
+                { lowerChoices(); }
+
+      DgStringChoiceParam (const std::string& nameIn, const std::string& valIn,
+                           const std::vector<std::string>& choicesIn,
+                           bool validIn = true)
+          : DgChoiceParam<std::string> (nameIn, valIn, choicesIn, validIn)
+                {
+                   lowerChoices();
+
+                   if (!validate()) {
+                     report(
+                       std::string("Invalid initialization data for parameter:\n")
+                        + name() + " " + valToStr() +std::string("\n") +
+                        validationErrMsg(), DgBase::Fatal);
+                   }
+                }
+
+   private:
+      void lowerChoices()
+            {
+               for (unsigned int i = 0; i < choices_.size(); i++) {
+                  *choices_[i] = toLower(*choices_[i]);
+               }
+            }
 
       virtual std::string valToStr (void) const { return value_; }
       virtual std::string strToVal (const std::string& strVal) const { return strVal; }
@@ -672,6 +753,22 @@ class DgStringChoiceParam : public DgChoiceParam<std::string> {
                    return this->setIsValid(false);
                 }
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// Definition of convenience overload (must come after DgStringChoiceParam is defined)
+inline void DgApParamList::insertParam (const std::string& name,
+                                        const std::string& defaultValue,
+                                        std::initializer_list<std::string> choices)
+{
+   insertParam(new DgStringChoiceParam(name, defaultValue, choices));
+}
+
+inline void DgApParamList::insertParam (const std::string& name,
+                                        const std::string& defaultValue,
+                                        const std::vector<std::string>& choices)
+{
+   insertParam(new DgStringChoiceParam(name, defaultValue, choices));
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/lib/dglib/include/dglib/DgAddressType.h
+++ b/src/lib/dglib/include/dglib/DgAddressType.h
@@ -51,6 +51,33 @@ static const std::string hierNdxFormTypeStrings[] = {
     "INT64", "DIGIT_STRING", "NONE"
 };
 
+/// Return the valid choices for address types (excludes the "NONE" sentinel).
+inline std::vector<std::string> addressTypeChoices()
+{
+    std::vector<std::string> v;
+    for (int i = 0; addTypeStrings[i] != "NONE"; ++i)
+        v.push_back(addTypeStrings[i]);
+    return v;
+}
+
+/// Return the valid choices for hierarchical index systems (excludes "NONE").
+inline std::vector<std::string> hierNdxSysTypeChoices()
+{
+    std::vector<std::string> v;
+    for (int i = 0; hierNdxSysTypeStrings[i] != "NONE"; ++i)
+        v.push_back(hierNdxSysTypeStrings[i]);
+    return v;
+}
+
+/// Return the valid choices for hierarchical index forms (excludes "NONE").
+inline std::vector<std::string> hierNdxFormTypeChoices()
+{
+    std::vector<std::string> v;
+    for (int i = 0; hierNdxFormTypeStrings[i] != "NONE"; ++i)
+        v.push_back(hierNdxFormTypeStrings[i]);
+    return v;
+}
+
 DgAddressType stringToAddressType (const std::string& str);
 const std::string& to_string (DgAddressType t);
 


### PR DESCRIPTION
…string> support

- Added initializer_list and vector<string> constructors to DgChoiceParam / DgStringChoiceParam
- Added convenience insertParam(name, default, choices) overloads on DgApParamList
- Added addressTypeChoices(), hierNdxSysTypeChoices(), hierNdxFormTypeChoices() helpers
- Converted all ~40 verbose choice param sites to clean one-liners
- Fixed latent bug in old addChoices path

This resolves the repetitive vector<string*> + manual new + release pattern.